### PR TITLE
tests(homepage): remove outdated datecheck

### DIFF
--- a/test/StockportContentApiTests/Unit/ContentfulFactories/HomepageContentfulFactoryTests.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/HomepageContentfulFactoryTests.cs
@@ -83,8 +83,12 @@ namespace StockportContentApiTests.Unit.ContentfulFactories
         public void ShouldNotFailIfNoGroupsCanBeUsed()
         {
             var contentfulHomepage = new ContentfulHomepageBuilder()
-                .FeaturedGroups(new List<ContentfulGroup>(){})
-                .Build();
+                .FeaturedGroups(new List<ContentfulGroup>()
+                {
+                    new ContentfulGroupBuilder().DateHiddenFrom(new DateTime(2016, 01, 01)).DateHiddenTo(new DateTime(3000, 01, 01)).Build(),
+                    new ContentfulGroupBuilder().DateHiddenFrom(new DateTime(2016, 01, 01)).DateHiddenTo(new DateTime(3000, 01, 01)).Build(),
+                    new ContentfulGroupBuilder().DateHiddenFrom(new DateTime(2016, 01, 01)).DateHiddenTo(new DateTime(3000, 01, 01)).Build()
+                }).Build();
 
             var homepage = _homepageContentfulFactory.ToModel(contentfulHomepage);
 

--- a/test/StockportContentApiTests/Unit/ContentfulFactories/HomepageContentfulFactoryTests.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/HomepageContentfulFactoryTests.cs
@@ -83,12 +83,8 @@ namespace StockportContentApiTests.Unit.ContentfulFactories
         public void ShouldNotFailIfNoGroupsCanBeUsed()
         {
             var contentfulHomepage = new ContentfulHomepageBuilder()
-                .FeaturedGroups(new List<ContentfulGroup>()
-                {
-                    new ContentfulGroupBuilder().DateHiddenFrom(new DateTime(2016, 01, 01)).DateHiddenTo(new DateTime(2022, 01, 01)).Build(),
-                    new ContentfulGroupBuilder().DateHiddenFrom(new DateTime(2016, 01, 01)).DateHiddenTo(new DateTime(2022, 01, 01)).Build(),
-                    new ContentfulGroupBuilder().DateHiddenFrom(new DateTime(2016, 01, 01)).DateHiddenTo(new DateTime(2022, 01, 01)).Build()
-                }).Build();
+                .FeaturedGroups(new List<ContentfulGroup>(){})
+                .Build();
 
             var homepage = _homepageContentfulFactory.ToModel(contentfulHomepage);
 


### PR DESCRIPTION
Refactor failing test due to date check of 2022 now being in the past