### PR TITLE
fix(PrivacyNotices): better handling of non-existant slugs being requ…

### DIFF
--- a/src/StockportContentApi/Controllers/PrivacyNoticeController.cs
+++ b/src/StockportContentApi/Controllers/PrivacyNoticeController.cs
@@ -32,14 +32,10 @@ namespace StockportContentApi.Controllers
                 var repository = _privacyNoticeRepository(_createConfig(businessId));
                 var privacyNotice = await repository.GetPrivacyNotice(slug);
 
-                if (privacyNotice == null)
-                {
+                if (privacyNotice is null)
                     return HttpResponse.Failure(System.Net.HttpStatusCode.NotFound, "Privacy notice not found");
-                }
-                else
-                {
-                    return HttpResponse.Successful(privacyNotice);
-                }
+
+                return HttpResponse.Successful(privacyNotice);
             });
         }
 

--- a/src/StockportContentApi/Repositories/PrivacyNoticeRepository.cs
+++ b/src/StockportContentApi/Repositories/PrivacyNoticeRepository.cs
@@ -36,9 +36,7 @@ namespace StockportContentApi.Repositories
 
             var entry = entries.FirstOrDefault();
 
-            var privacyNotice = _contentfulFactory.ToModel(entry);
-
-            return privacyNotice;
+            return entry is not null ? _contentfulFactory.ToModel(entry) : null;
         }
 
         public async Task<List<PrivacyNotice>> GetAllPrivacyNotices()


### PR DESCRIPTION
…ested

If a user searches for a non-existent privacy notice there was an uncaught exception when trying to map a null response to a model. Added handling of null response to just return null which is then handled by the Controller to return 424. No change to user experience