### PR TITLE
Enable video tag parser in body text of content types

### DIFF
--- a/src/StockportContentApi/ContentfulFactories/TopicFactories/TopicContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/TopicFactories/TopicContentfulFactory.cs
@@ -1,6 +1,7 @@
 using System.Linq;
 using StockportContentApi.ContentfulModels;
 using StockportContentApi.Model;
+using StockportContentApi.Repositories;
 using StockportContentApi.Utils;
 
 namespace StockportContentApi.ContentfulFactories.TopicFactories
@@ -13,8 +14,9 @@ namespace StockportContentApi.ContentfulFactories.TopicFactories
         private readonly IContentfulFactory<ContentfulEventBanner, EventBanner> _eventBannerFactory;
         private readonly DateComparer _dateComparer;
         private readonly IContentfulFactory<ContentfulExpandingLinkBox, ExpandingLinkBox> _expandingLinkBoxFactory;
+        private readonly IVideoRepository _videoRepository;
 
-        public TopicContentfulFactory(IContentfulFactory<ContentfulReference, SubItem> subItemFactory, IContentfulFactory<ContentfulReference, Crumb> crumbFactory, IContentfulFactory<ContentfulAlert, Alert> alertFactory, IContentfulFactory<ContentfulEventBanner, EventBanner> eventBannerFactory, IContentfulFactory<ContentfulExpandingLinkBox, ExpandingLinkBox> expandingLinkBoxFactory, ITimeProvider timeProvider)
+        public TopicContentfulFactory(IContentfulFactory<ContentfulReference, SubItem> subItemFactory, IContentfulFactory<ContentfulReference, Crumb> crumbFactory, IContentfulFactory<ContentfulAlert, Alert> alertFactory, IContentfulFactory<ContentfulEventBanner, EventBanner> eventBannerFactory, IContentfulFactory<ContentfulExpandingLinkBox, ExpandingLinkBox> expandingLinkBoxFactory, ITimeProvider timeProvider, IVideoRepository videoRepository)
 
         {
             _subItemFactory = subItemFactory;
@@ -23,6 +25,7 @@ namespace StockportContentApi.ContentfulFactories.TopicFactories
             _dateComparer = new DateComparer(timeProvider);
             _eventBannerFactory = eventBannerFactory;
             _expandingLinkBoxFactory = expandingLinkBoxFactory;
+            _videoRepository = videoRepository;
         }
 
         public Topic ToModel(ContentfulTopic entry)
@@ -63,10 +66,12 @@ namespace StockportContentApi.ContentfulFactories.TopicFactories
 
             var displayContactUs = entry.DisplayContactUs;
 
+            var body = !string.IsNullOrEmpty(entry.Body) ? _videoRepository.Process(entry.Body) : string.Empty;
+
             return new Topic(entry.Slug, entry.Name, entry.Teaser, entry.MetaDescription, entry.Summary, entry.Icon, backgroundImage, image,
                 subItems, secondaryItems, tertiaryItems, breadcrumbs, alerts, entry.SunriseDate, entry.SunsetDate, 
                 entry.EmailAlerts, entry.EmailAlertsTopicId, eventBanner, entry.ExpandingLinkTitle,
-                expandingLinkBoxes, primaryItemTitle, displayContactUs);
+                expandingLinkBoxes, primaryItemTitle, displayContactUs, body);
         }
     }
 }

--- a/src/StockportContentApi/ContentfulModels/ContentfulTopic.cs
+++ b/src/StockportContentApi/ContentfulModels/ContentfulTopic.cs
@@ -20,5 +20,7 @@ namespace StockportContentApi.ContentfulModels
         public string PrimaryItemTitle { get; set; }
 
         public bool DisplayContactUs { get; set; } = true;
+        public string Body { get; set; } = string.Empty;
+
     }
 }

--- a/src/StockportContentApi/Extensions/ServiceCollectionExtensions.cs
+++ b/src/StockportContentApi/Extensions/ServiceCollectionExtensions.cs
@@ -104,7 +104,8 @@ namespace StockportContentApi.Extensions
                 p.GetService<IContentfulFactory<ContentfulAlert, Alert>>(),
                 p.GetService<IContentfulFactory<ContentfulEventBanner, EventBanner>>(),
                 p.GetService<IContentfulFactory<ContentfulExpandingLinkBox, ExpandingLinkBox>>(),
-                p.GetService<ITimeProvider>()));
+                p.GetService<ITimeProvider>(),
+                p.GetService<IVideoRepository>()));
             services.AddSingleton<IContentfulFactory<ContentfulCallToActionBanner, CallToActionBanner>>(p => new CallToActionBannerContentfulFactory());
             services.AddSingleton<IContentfulFactory<ContentfulShowcase, Showcase>>
             (p => new ShowcaseContentfulFactory(p.GetService<IContentfulFactory<ContentfulReference, SubItem>>(), p.GetService<IContentfulFactory<ContentfulReference, Crumb>>(), p.GetService<ITimeProvider>(),
@@ -288,7 +289,7 @@ namespace StockportContentApi.Extensions
             services.AddSingleton<Func<ContentfulConfig, SectionRepository>>(
                 p => { return x => new SectionRepository(x, p.GetService<IContentfulFactory<ContentfulSection, Section>>(), p.GetService<IContentfulClientManager>(), p.GetService<ITimeProvider>()); });
             services.AddSingleton<Func<ContentfulConfig, TopicRepository>>(
-                p => { return x => new TopicRepository(x, p.GetService<IContentfulClientManager>(), p.GetService<IContentfulFactory<ContentfulTopic, Topic>>(), p.GetService<IContentfulFactory<ContentfulTopicForSiteMap, TopicSiteMap>>()); });
+                p => { return x => new TopicRepository(x, p.GetService<IContentfulClientManager>(), p.GetService<IContentfulFactory<ContentfulTopic, Topic>>(), p.GetService<IContentfulFactory<ContentfulTopicForSiteMap, TopicSiteMap>>(), p.GetService<IVideoRepository>()); });
             services.AddSingleton<RedirectsRepository>();
             services.AddSingleton<IAuthenticationHelper>(p => new AuthenticationHelper(p.GetService<ITimeProvider>()));
             services.AddSingleton<Func<ContentfulConfig, IGroupRepository>>(

--- a/src/StockportContentApi/Model/Topic.cs
+++ b/src/StockportContentApi/Model/Topic.cs
@@ -30,6 +30,7 @@ namespace StockportContentApi.Model
         public string PrimaryItemTitle { get; set; }
 
         public bool DisplayContactUs { get; }
+        public string Body { get; set; }
 
         public Topic(string title, string slug, IEnumerable<SubItem> subItems, IEnumerable<SubItem> secondayItems,
             IEnumerable<SubItem> tertiaryItems)
@@ -45,7 +46,7 @@ namespace StockportContentApi.Model
             string image, IEnumerable<SubItem> subItems, IEnumerable<SubItem> secondayItems, IEnumerable<SubItem> tertiaryItems,
             IEnumerable<Crumb> breadcrumbs, IEnumerable<Alert> alerts, DateTime sunriseDate, DateTime sunsetDate, bool emailAlerts, 
             string emailAlertsTopicId, EventBanner eventBanner, string expandingLinkTitle,
-            IEnumerable<ExpandingLinkBox> expandingLinkBoxes = null, string primaryItemTitle = null, bool displayContactUs = true)
+            IEnumerable<ExpandingLinkBox> expandingLinkBoxes = null, string primaryItemTitle = null, bool displayContactUs = true, string body = null)
         {
             Slug = slug;
             Name = name;
@@ -69,6 +70,7 @@ namespace StockportContentApi.Model
             ExpandingLinkBoxes = expandingLinkBoxes;
             PrimaryItemTitle = primaryItemTitle;
             DisplayContactUs = displayContactUs;
+            Body = body;
         }
     }
 
@@ -96,7 +98,8 @@ namespace StockportContentApi.Model
             string.Empty,
             new List<ExpandingLinkBox>(),
             string.Empty,
-            true
+            true,
+            String.Empty
             )
         {
         }

--- a/src/StockportContentApi/Repositories/TopicRepository.cs
+++ b/src/StockportContentApi/Repositories/TopicRepository.cs
@@ -17,14 +17,17 @@ namespace StockportContentApi.Repositories
         private readonly IContentfulFactory<ContentfulTopic, Topic> _topicFactory;
         private readonly IContentfulFactory<ContentfulTopicForSiteMap, TopicSiteMap> _topicSiteMapFactory;
         private readonly Contentful.Core.IContentfulClient _client;
+        private readonly IVideoRepository _videoRepository;
 
         public TopicRepository(ContentfulConfig config, IContentfulClientManager clientManager,
                    IContentfulFactory<ContentfulTopic, Topic> topicFactory,
-                   IContentfulFactory<ContentfulTopicForSiteMap, TopicSiteMap> topicSiteMapFactory)
+                   IContentfulFactory<ContentfulTopicForSiteMap, TopicSiteMap> topicSiteMapFactory,
+                   IVideoRepository videoRepository)
         {
             _client = clientManager.GetClient(config);
             _topicFactory = topicFactory;
             _topicSiteMapFactory = topicSiteMapFactory;
+            _videoRepository = videoRepository;
         }
 
         public async Task<HttpResponse> GetTopicByTopicSlug(string slug)
@@ -37,6 +40,8 @@ namespace StockportContentApi.Repositories
             if (entry == null) return HttpResponse.Failure(HttpStatusCode.NotFound, $"No topic found for '{slug}'");
 
             var model = _topicFactory.ToModel(entry);
+
+            model.Body = _videoRepository.Process(model.Body);
 
             return HttpResponse.Successful(model);
         }

--- a/test/StockportContentApiTests/Integration/ExpectedContentApiResponses/PrivacyNotice.json
+++ b/test/StockportContentApiTests/Integration/ExpectedContentApiResponses/PrivacyNotice.json
@@ -47,6 +47,7 @@
     "expandingLinkBoxes": [
     ],
     "primaryItemTitle": "",
-    "displayContactUs": true
+    "displayContactUs": true,
+    "body":  ""
   }
 }

--- a/test/StockportContentApiTests/Integration/ExpectedContentApiResponses/PrivacyNotice.json
+++ b/test/StockportContentApiTests/Integration/ExpectedContentApiResponses/PrivacyNotice.json
@@ -47,7 +47,6 @@
     "expandingLinkBoxes": [
     ],
     "primaryItemTitle": "",
-    "displayContactUs": true,
-    "body":  ""
+    "displayContactUs": true
   }
 }

--- a/test/StockportContentApiTests/Integration/ExpectedContentApiResponses/Topic.json
+++ b/test/StockportContentApiTests/Integration/ExpectedContentApiResponses/Topic.json
@@ -95,5 +95,6 @@
     }
   ],
   "primaryItemTitle": null,
-  "displayContactUs": false
+  "displayContactUs": false,
+  "body": "body"
 }

--- a/test/StockportContentApiTests/Unit/Builders/ContentfulTopicBuilder.cs
+++ b/test/StockportContentApiTests/Unit/Builders/ContentfulTopicBuilder.cs
@@ -64,6 +64,7 @@ namespace StockportContentApiTests.Unit.Builders
                 ExpandingLinkTitle = _expandingLinkTitle,
                 ExpandingLinkBoxes = _expandingLinkBox,
                 DisplayContactUs = false,
+                Body = "body",
                 Sys = new SystemProperties()
                 {
                     ContentType = new ContentType { SystemProperties = new SystemProperties { Id = _contentTypeSystemId } },

--- a/test/StockportContentApiTests/Unit/ContentfulFactories/TopicContentfulFactoryTest.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/TopicContentfulFactoryTest.cs
@@ -10,6 +10,7 @@ using StockportContentApi.Utils;
 using StockportContentApiTests.Unit.Builders;
 using Xunit;
 using StockportContentApi.ContentfulFactories.TopicFactories;
+using StockportContentApi.Repositories;
 
 namespace StockportContentApiTests.Unit.ContentfulFactories
 {
@@ -24,6 +25,8 @@ namespace StockportContentApiTests.Unit.ContentfulFactories
         private readonly Mock<IContentfulFactory<ContentfulExpandingLinkBox, ExpandingLinkBox>> _expandingLinkBoxFactory;
         private readonly TopicContentfulFactory _topicContentfulFactory;
         private readonly Mock<ITimeProvider> _timeProvider = new Mock<ITimeProvider>();
+        private readonly Mock<IVideoRepository> _videoRepository;
+
 
         public TopicContentfulFactoryTest()
         {
@@ -34,7 +37,7 @@ namespace StockportContentApiTests.Unit.ContentfulFactories
             _eventBannerFactory = new Mock<IContentfulFactory<ContentfulEventBanner, EventBanner>>();
             _expandingLinkBoxFactory = new Mock<IContentfulFactory<ContentfulExpandingLinkBox, ExpandingLinkBox>>();
             _timeProvider.Setup(o => o.Now()).Returns(new DateTime(2017, 02, 02));
-            _topicContentfulFactory = new TopicContentfulFactory(_subItemFactory.Object, _crumbFactory.Object, _alertFactory.Object, _eventBannerFactory.Object, _expandingLinkBoxFactory.Object, _timeProvider.Object);
+            _topicContentfulFactory = new TopicContentfulFactory(_subItemFactory.Object, _crumbFactory.Object, _alertFactory.Object, _eventBannerFactory.Object, _expandingLinkBoxFactory.Object, _timeProvider.Object, _videoRepository.Object);
         }
 
         [Fact]

--- a/test/StockportContentApiTests/Unit/ContentfulFactories/TopicContentfulFactoryTest.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/TopicContentfulFactoryTest.cs
@@ -37,6 +37,7 @@ namespace StockportContentApiTests.Unit.ContentfulFactories
             _eventBannerFactory = new Mock<IContentfulFactory<ContentfulEventBanner, EventBanner>>();
             _expandingLinkBoxFactory = new Mock<IContentfulFactory<ContentfulExpandingLinkBox, ExpandingLinkBox>>();
             _timeProvider.Setup(o => o.Now()).Returns(new DateTime(2017, 02, 02));
+            _videoRepository = new Mock<IVideoRepository>();
             _topicContentfulFactory = new TopicContentfulFactory(_subItemFactory.Object, _crumbFactory.Object, _alertFactory.Object, _eventBannerFactory.Object, _expandingLinkBoxFactory.Object, _timeProvider.Object, _videoRepository.Object);
         }
 
@@ -97,6 +98,7 @@ namespace StockportContentApiTests.Unit.ContentfulFactories
             result.Teaser.Should().BeEquivalentTo("teaser");
             result.MetaDescription.Should().BeEquivalentTo("metaDescription");
             result.DisplayContactUs.Should().Be(false);
+            result.Body.Should().Be(null);
         }
 
         [Fact]

--- a/test/StockportContentApiTests/Unit/Repositories/TopicRepositoryTest.cs
+++ b/test/StockportContentApiTests/Unit/Repositories/TopicRepositoryTest.cs
@@ -26,6 +26,7 @@ namespace StockportContentApiTests.Unit.Repositories
         private readonly Mock<IContentfulFactory<ContentfulTopic, Topic>> _topicFactory;
         private readonly Mock<Contentful.Core.IContentfulClient> _contentfulClient;
         private readonly Mock<IContentfulFactory<ContentfulTopicForSiteMap, TopicSiteMap>> _topicSiteMapFactory;
+        private readonly Mock<IVideoRepository> _videoRepository;
 
         public TopicRepositoryTest()
         {
@@ -58,7 +59,7 @@ namespace StockportContentApiTests.Unit.Repositories
             _contentfulClient = new Mock<Contentful.Core.IContentfulClient>();
             contentfulClientManager.Setup(o => o.GetClient(config)).Returns(_contentfulClient.Object);
 
-            _repository = new TopicRepository(config, contentfulClientManager.Object, _topicFactory.Object, _topicSiteMapFactory.Object);
+            _repository = new TopicRepository(config, contentfulClientManager.Object, _topicFactory.Object, _topicSiteMapFactory.Object, _videoRepository.Object);
         }
 
         [Fact]

--- a/test/StockportContentApiTests/Unit/Repositories/TopicRepositoryTest.cs
+++ b/test/StockportContentApiTests/Unit/Repositories/TopicRepositoryTest.cs
@@ -59,6 +59,8 @@ namespace StockportContentApiTests.Unit.Repositories
             _contentfulClient = new Mock<Contentful.Core.IContentfulClient>();
             contentfulClientManager.Setup(o => o.GetClient(config)).Returns(_contentfulClient.Object);
 
+            _videoRepository = new Mock<IVideoRepository>();
+
             _repository = new TopicRepository(config, contentfulClientManager.Object, _topicFactory.Object, _topicSiteMapFactory.Object, _videoRepository.Object);
         }
 


### PR DESCRIPTION
Jira Card - Enable video tag parser in body text of content types

-) Update TopicContentfulFactory/VideoRespository to include videoRepository to process the body content.
-) Update ContentTopic/Topic mode to include 'Body' property.
-) Add body to json test object.
-) Update ServiceExtension.cs to include timeProvider and videoRepository .


Checklist
- [x] Code compiles correctly
- [ ] Created tests for the new changes
- [x] All tests passing
- [ ] Extended the README / documentation, if necessary