### PR TITLE
feat(HS): allow background image if no "hero" image

### DIFF
--- a/src/StockportContentApi/ContentfulFactories/SubItemContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/SubItemContentfulFactory.cs
@@ -20,12 +20,17 @@ namespace StockportContentApi.ContentfulFactories
         {
             var type = GetEntryType(entry);
             var image = GetEntryImage(entry);
+            if (string.IsNullOrEmpty(image))
+            {
+                image = ContentfulHelpers.EntryIsNotALink(entry.BackgroundImage.SystemProperties)
+                            ? entry.BackgroundImage.File.Url : string.Empty;
+            }
+
             var title = GetEntryTitle(entry);
 
             // build all of the sub items (only avaliable for topics)
-            var subItems = new List<SubItem>();
-
-            if (entry.SubItems != null)
+            List<SubItem> subItems = new();
+            if (entry.SubItems is not null)
             {
                 foreach (var item in entry.SubItems.Where(EntryIsValid))
                 {
@@ -68,8 +73,7 @@ namespace StockportContentApi.ContentfulFactories
 
             var handledSlug = HandleSlugForGroupsHomepage(entry.Sys, entry.Slug);
 
-            return new SubItem(handledSlug, title, entry.Teaser, 
-                entry.Icon, type, entry.SunriseDate, entry.SunsetDate, image, subItems);
+            return new SubItem(handledSlug, title, entry.Teaser, entry.Icon, type, entry.SunriseDate, entry.SunsetDate, image, subItems);
         }
 
         private static string HandleSlugForGroupsHomepage(SystemProperties sys, string entrySlug)

--- a/src/StockportContentApi/ContentfulModels/ContentfulReference.cs
+++ b/src/StockportContentApi/ContentfulModels/ContentfulReference.cs
@@ -19,6 +19,7 @@ namespace StockportContentApi.ContentfulModels
         public DateTime SunsetDate { get; set; } = DateTime.MaxValue.ToUniversalTime();
         public bool HideLastUpdated { get; set; } = false;
         public Asset Image { get; set; } = new Asset { File = new File { Url = string.Empty }, SystemProperties = new SystemProperties { Type = "Asset" } };
+        public Asset BackgroundImage { get; set; } = new Asset { File = new File { Url = string.Empty }, SystemProperties = new SystemProperties { Type = "Asset" } };
         public List<ContentfulReference> SubItems { get; set; } = new List<ContentfulReference>();
         public List<ContentfulReference> SecondaryItems { get; set; } = new List<ContentfulReference>();
         public List<ContentfulReference> TertiaryItems { get; set; } = new List<ContentfulReference>();

--- a/src/StockportContentApi/ContentfulModels/ContentfulTopic.cs
+++ b/src/StockportContentApi/ContentfulModels/ContentfulTopic.cs
@@ -6,7 +6,6 @@ namespace StockportContentApi.ContentfulModels
     public class ContentfulTopic : ContentfulReference
     {
         public string Summary { get; set; } = string.Empty;
-        public Asset BackgroundImage { get; set; } = new Asset { File = new File { Url = string.Empty }, SystemProperties = new SystemProperties { Type = "Asset" } };
         public List<ContentfulReference> Breadcrumbs { get; set; } = new List<ContentfulReference>();
         public List<ContentfulAlert> Alerts { get; set; } = new List<ContentfulAlert>();
         public bool EmailAlerts { get; set; } = false;
@@ -18,7 +17,6 @@ namespace StockportContentApi.ContentfulModels
             Sys = new SystemProperties { Type = "Entry" }
         };
         public string PrimaryItemTitle { get; set; }
-
         public bool DisplayContactUs { get; set; } = true;
     }
 }


### PR DESCRIPTION
For [Jira #8615](https://stockportbi.atlassian.net/browse/DIGITAL-8615) Sub Items of Topics to have images...

Moved Background Image to base ContentfulReference to allow for topics that don't have a "Hero" image to fallback to a "Background" image. Healthy Stockport mostly uses "backgroundImage" Field ID.

Added logic in SubItem ( which could be article/topic/showcase ) to allow for background images to pass through to the view if no hero image is available.