### PR TITLE
Fix/null assets

### DIFF
--- a/src/StockportContentApi/ContentfulFactories/ArticleFactories/ArticleContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/ArticleFactories/ArticleContentfulFactory.cs
@@ -65,10 +65,10 @@ namespace StockportContentApi.ContentfulFactories.ArticleFactories
                                                                 && _dateComparer.DateNowIsWithinSunriseAndSunsetDates(section.SunriseDate, section.SunsetDate))
                                      .Select(alertInline => _alertFactory.ToModel(alertInline));
 
-            var backgroundImage = ContentfulHelpers.EntryIsNotALink(entry.BackgroundImage.SystemProperties)
+            var backgroundImage = entry.BackgroundImage?.SystemProperties is not null && ContentfulHelpers.EntryIsNotALink(entry.BackgroundImage.SystemProperties)
                                         ? entry.BackgroundImage.File.Url : string.Empty;
 
-            var image = ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties)
+            var image = entry.Image?.SystemProperties is not null && ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties)
                                         ? entry.Image.File.Url : string.Empty;
 
             var sectionUpdatedAt = entry.Sections

--- a/src/StockportContentApi/ContentfulFactories/CarouselContentContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/CarouselContentContentfulFactory.cs
@@ -11,7 +11,8 @@ namespace StockportContentApi.ContentfulFactories
             var title = carousel.Title ?? string.Empty;
             var slug = carousel.Slug ?? string.Empty;
             var teaser = carousel.Teaser ?? string.Empty;
-            var image = ContentfulHelpers.EntryIsNotALink(carousel.Image.SystemProperties) ? carousel.Image.File.Url : string.Empty;
+            var image = carousel.Image?.SystemProperties is not null && ContentfulHelpers.EntryIsNotALink(carousel.Image.SystemProperties) ? 
+                carousel.Image.File.Url : string.Empty;
 
             var url = carousel.Url ?? string.Empty;
 

--- a/src/StockportContentApi/ContentfulFactories/EventFactories/EventContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/EventFactories/EventContentfulFactory.cs
@@ -30,9 +30,8 @@ namespace StockportContentApi.ContentfulFactories.EventFactories
                 entry.Documents.Where(document => ContentfulHelpers.EntryIsNotALink(document.SystemProperties))
                     .Select(document => _documentFactory.ToModel(document)).ToList();
 
-            var imageUrl = ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties)
-                ? entry.Image?.File?.Url
-                : string.Empty;
+            var imageUrl = entry.Image?.SystemProperties is not null && ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties) ?
+                entry.Image?.File?.Url : string.Empty;
 
             var group = _groupFactory.ToModel(entry.Group);
 

--- a/src/StockportContentApi/ContentfulFactories/GroupFactories/GroupCategoryContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/GroupFactories/GroupCategoryContentfulFactory.cs
@@ -20,9 +20,8 @@ namespace StockportContentApi.ContentfulFactories.GroupFactories
                 ? entry.Icon
                 : "";
 
-            var image = ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties)
-                ? entry.Image.File.Url
-                : string.Empty;
+            var image = entry.Image?.SystemProperties is not null && ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties) ?
+                entry.Image.File.Url : string.Empty;
 
             return new GroupCategory(name, slug, icon, image);
         }

--- a/src/StockportContentApi/ContentfulFactories/GroupFactories/GroupContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/GroupFactories/GroupContentfulFactory.cs
@@ -39,11 +39,8 @@ namespace StockportContentApi.ContentfulFactories.GroupFactories
 
         public Group ToModel(ContentfulGroup entry)
         {
-            var imageUrl = entry.Image != null
-                ? ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties)
-                    ? entry.Image.File.Url
-                    : string.Empty
-                : string.Empty;
+            var imageUrl = entry.Image?.SystemProperties is not null && ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties) ?
+                entry.Image.File.Url : string.Empty;
 
             var categoriesReferences = entry.CategoriesReference != null
                 ? entry.CategoriesReference.Where(o => o != null).Select(catogory => _contentfulGroupCategoryFactory.ToModel(catogory)).ToList()

--- a/src/StockportContentApi/ContentfulFactories/HomepageContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/HomepageContentfulFactory.cs
@@ -25,7 +25,7 @@ namespace StockportContentApi.ContentfulFactories
         {
             var featuredTasksHeading = !string.IsNullOrEmpty(entry.FeaturedTasksHeading) ? entry.FeaturedTasksHeading : string.Empty;
             var featuredTasksSummary = !string.IsNullOrEmpty(entry.FeaturedTasksSummary) ? entry.FeaturedTasksSummary : string.Empty;
-            var backgroundImage = !string.IsNullOrEmpty(entry.BackgroundImage.File?.Url) ? entry.BackgroundImage.File.Url : string.Empty;
+            var backgroundImage = !string.IsNullOrEmpty(entry.BackgroundImage?.File?.Url) ? entry.BackgroundImage.File.Url : string.Empty;
             var freeText = !string.IsNullOrEmpty(entry.FreeText) ? entry.FreeText : string.Empty;
 
             var popularSearchTerms = ContentfulHelpers.ConvertToListOfStrings(entry.PopularSearchTerms);
@@ -45,7 +45,7 @@ namespace StockportContentApi.ContentfulFactories
                                             .Select(alert => _alertFactory.ToModel(alert)).ToList();
 
             var carouselContents =
-                entry.CarouselContents.Where(subItem => ContentfulHelpers.EntryIsNotALink(subItem.Sys)
+                entry.CarouselContents.Where(subItem => subItem.Sys is not null && ContentfulHelpers.EntryIsNotALink(subItem.Sys)
                     && _dateComparer.DateNowIsWithinSunriseAndSunsetDates(subItem.SunriseDate, subItem.SunsetDate))
                     .Select(item => _carouselFactory.ToModel(item)).ToList();
 

--- a/src/StockportContentApi/ContentfulFactories/NewsFactories/NewsContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/NewsFactories/NewsContentfulFactory.cs
@@ -24,9 +24,13 @@ namespace StockportContentApi.ContentfulFactories.NewsFactories
 
         public News ToModel(ContentfulNews entry)
         {
-            var documents = entry.Documents.Where(document => ContentfulHelpers.EntryIsNotALink(document.SystemProperties))
-                                           .Select(document => _documentFactory.ToModel(document)).ToList();
-            var imageUrl = ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties) ? entry.Image.File.Url : string.Empty;
+            var documents = entry.Documents
+                .Where(document => ContentfulHelpers.EntryIsNotALink(document.SystemProperties))
+                .Select(document => _documentFactory.ToModel(document))
+                .ToList();
+
+            var imageUrl = entry.Image?.SystemProperties is not null && ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties) ?
+                entry.Image.File.Url : string.Empty;
 
             var alerts = entry.Alerts.Where(section => ContentfulHelpers.EntryIsNotALink(section.Sys)
                                       && _dateComparer.DateNowIsWithinSunriseAndSunsetDates(section.SunriseDate, section.SunsetDate))

--- a/src/StockportContentApi/ContentfulFactories/OrganisationContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/OrganisationContentfulFactory.cs
@@ -8,11 +8,8 @@ namespace StockportContentApi.ContentfulFactories
     {
         public Organisation ToModel(ContentfulOrganisation entry)
         {
-            var imageUrl = entry.Image != null
-                ? ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties)
-                    ? entry.Image.File.Url
-                    : string.Empty
-                : string.Empty;
+            var imageUrl = entry.Image?.SystemProperties is not null && ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties) ?
+                entry.Image.File.Url : string.Empty;
 
             return new Organisation(entry.Title, entry.Slug, imageUrl, entry.AboutUs, entry.Phone, entry.Email,
                 entry.Volunteering, entry.VolunteeringText, entry.Donations, entry.DonationsText, entry.DonationsUrl);

--- a/src/StockportContentApi/ContentfulFactories/ProfileContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/ProfileContentfulFactory.cs
@@ -34,7 +34,8 @@ namespace StockportContentApi.ContentfulFactories
             var alerts = entry.Alerts.Where(alert => ContentfulHelpers.EntryIsNotALink(alert.Sys))
                                      .Select(alert => _alertFactory.ToModel(alert)).ToList();
 
-            var imageUrl = ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties) ? entry.Image.File.Url : string.Empty;
+            var imageUrl = entry.Image?.SystemProperties is not null && ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties) ?
+                entry.Image.File.Url : string.Empty;
 
             var triviaSubheading = !string.IsNullOrEmpty(entry.TriviaSubheading)
                 ? entry.TriviaSubheading

--- a/src/StockportContentApi/ContentfulFactories/ShowcaseContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/ShowcaseContentfulFactory.cs
@@ -42,9 +42,8 @@ namespace StockportContentApi.ContentfulFactories
 
         public Showcase ToModel(ContentfulShowcase entry)
         {
-            var heroImage = ContentfulHelpers.EntryIsNotALink(entry.HeroImage.SystemProperties)
-                ? entry.HeroImage.File.Url
-                : string.Empty;
+            var heroImage = entry.HeroImage?.SystemProperties is not null && ContentfulHelpers.EntryIsNotALink(entry.HeroImage.SystemProperties) ?
+                entry.HeroImage.File.Url : string.Empty;
 
             var primaryItems =
                 entry.PrimaryItems.Where(primItem => ContentfulHelpers.EntryIsNotALink(primItem.Sys)

--- a/src/StockportContentApi/ContentfulFactories/SubItemContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/SubItemContentfulFactory.cs
@@ -1,4 +1,5 @@
-﻿using Contentful.Core.Models;
+﻿using System.Diagnostics.CodeAnalysis;
+using Contentful.Core.Models;
 using StockportContentApi.ContentfulModels;
 using StockportContentApi.Model;
 using StockportContentApi.Utils;
@@ -18,10 +19,11 @@ namespace StockportContentApi.ContentfulFactories
         {
             var type = GetEntryType(entry);
             var image = GetEntryImage(entry);
-            if (string.IsNullOrEmpty(image))
+            if (string.IsNullOrEmpty(image) &&
+                entry.BackgroundImage?.SystemProperties is not null &&
+                ContentfulHelpers.EntryIsNotALink(entry.BackgroundImage.SystemProperties))
             {
-                image = ContentfulHelpers.EntryIsNotALink(entry.BackgroundImage.SystemProperties)
-                            ? entry.BackgroundImage.File.Url : string.Empty;
+                image = entry.BackgroundImage.File.Url;
             }
 
             var title = GetEntryTitle(entry);
@@ -86,7 +88,8 @@ namespace StockportContentApi.ContentfulFactories
 
         private string GetEntryImage(ContentfulReference entry)
         {
-            return ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties) ? entry.Image.File.Url : string.Empty;
+            return entry.Image?.SystemProperties is not null && ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties) ? 
+                entry.Image.File.Url : string.Empty;
         }
 
         private string GetEntryTitle(ContentfulReference entry)

--- a/src/StockportContentApi/ContentfulFactories/TopicFactories/TopicContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/TopicFactories/TopicContentfulFactory.cs
@@ -56,10 +56,10 @@ namespace StockportContentApi.ContentfulFactories.TopicFactories
                                             && _dateComparer.DateNowIsWithinSunriseAndSunsetDates(alert.SunriseDate, alert.SunsetDate))
                                      .Select(alert => _alertFactory.ToModel(alert)).ToList();
 
-            var backgroundImage = ContentfulHelpers.EntryIsNotALink(entry.BackgroundImage.SystemProperties)
+            var backgroundImage = entry.BackgroundImage?.SystemProperties is not null && ContentfulHelpers.EntryIsNotALink(entry.BackgroundImage.SystemProperties)
                                         ? entry.BackgroundImage.File.Url : string.Empty;
 
-            var image = ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties)
+            var image = entry.Image?.SystemProperties is not null && ContentfulHelpers.EntryIsNotALink(entry.Image.SystemProperties)
                                         ? entry.Image.File.Url : string.Empty;
 
             var eventBanner = ContentfulHelpers.EntryIsNotALink(entry.EventBanner.Sys)

--- a/src/StockportContentApi/ContentfulModels/ContentfulArticle.cs
+++ b/src/StockportContentApi/ContentfulModels/ContentfulArticle.cs
@@ -6,18 +6,10 @@ namespace StockportContentApi.ContentfulModels
     public class ContentfulArticle : ContentfulReference
     {
         public string Body { get; set; } = string.Empty;
-        public Asset BackgroundImage { get; set; } = new Asset
-        {
-            File = new File { Url = string.Empty },
-            SystemProperties = new SystemProperties { Type = "Asset" }
-        };
-
         public List<ContentfulAlert> Alerts { get; set; } = new List<ContentfulAlert>();
         public List<ContentfulProfile> Profiles { get; set; } = new List<ContentfulProfile>();
         public List<Asset> Documents { get; set; } = new List<Asset>();
         public List<ContentfulAlert> AlertsInline { get; set; } = new List<ContentfulAlert>();
-
-        // references
         public List<ContentfulReference> Breadcrumbs { get; set; } = new List<ContentfulReference>();
     }
 }

--- a/src/StockportContentApi/ContentfulModels/ContentfulGroupHomepage.cs
+++ b/src/StockportContentApi/ContentfulModels/ContentfulGroupHomepage.cs
@@ -4,11 +4,6 @@ namespace StockportContentApi.ContentfulModels
 {
     public class ContentfulGroupHomepage : ContentfulReference
     {
-        public Asset BackgroundImage { get; set; } = new Asset
-        {
-            File = new File { Url = string.Empty },
-            SystemProperties = new SystemProperties { Type = "Asset" }
-        };
         public string FeaturedGroupsHeading { get; set; } = string.Empty;
         public List<ContentfulGroup> FeaturedGroups { get; set; } = new List<ContentfulGroup>();
         public ContentfulGroupCategory FeaturedGroupsCategory { get; set; } = new ContentfulGroupCategory();

--- a/src/StockportContentApi/Utils/ContentfulHelpers.cs
+++ b/src/StockportContentApi/Utils/ContentfulHelpers.cs
@@ -6,7 +6,7 @@ namespace StockportContentApi.Utils
     {
         public static bool EntryIsNotALink(SystemProperties sys)
         {
-            return sys.Type != "Link";
+            return sys.LinkType is null;
         }
 
         public static IEnumerable<string> ConvertToListOfStrings(IEnumerable<dynamic> term)

--- a/test/StockportContentApiTests/Unit/ContentfulFactories/ArticleContentfulFactoryTest.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/ArticleContentfulFactoryTest.cs
@@ -53,12 +53,12 @@ namespace StockportContentApiTests.Unit.ContentfulFactories
         [Fact]
         public void ShouldNotAddBackgroundImageOrSectionsOrBreadcrumbsOrAlertsOrProfilesOrParentTopicOrDocumentsOrLiveChatIfTheyAreLinks()
         {
-            _contentfulArticle.BackgroundImage.SystemProperties.Type = "Link";
-            _contentfulArticle.Sections.First().Sys.Type = "Link";
-            _contentfulArticle.Breadcrumbs.First().Sys.Type = "Link";
-            _contentfulArticle.Alerts.First().Sys.Type = "Link";
-            _contentfulArticle.Profiles.First().Sys.Type = "Link";
-            _contentfulArticle.Documents.First().SystemProperties.Type = "Link";
+            _contentfulArticle.BackgroundImage.SystemProperties.LinkType = "Link";
+            _contentfulArticle.Sections.First().Sys.LinkType = "Link";
+            _contentfulArticle.Breadcrumbs.First().Sys.LinkType = "Link";
+            _contentfulArticle.Alerts.First().Sys.LinkType = "Link";
+            _contentfulArticle.Profiles.First().Sys.LinkType = "Link";
+            _contentfulArticle.Documents.First().SystemProperties.LinkType = "Link";
 
             var article = _articleFactory.ToModel(_contentfulArticle);
 

--- a/test/StockportContentApiTests/Unit/ContentfulFactories/EventContentfulFactoryTest.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/EventContentfulFactoryTest.cs
@@ -47,8 +47,8 @@ namespace StockportContentApiTests.Unit.ContentfulFactories
         [Fact]
         public void ShouldNotAddDocumentsOrImageIfTheyAreLinks()
         {
-            _contentfulEvent.Documents.First().SystemProperties.Type = "Link";
-            _contentfulEvent.Image.SystemProperties.Type = "Link";
+            _contentfulEvent.Documents.First().SystemProperties.LinkType = "Link";
+            _contentfulEvent.Image.SystemProperties.LinkType = "Link";
 
             var anEvent = _eventContentfulFactory.ToModel(_contentfulEvent);
 

--- a/test/StockportContentApiTests/Unit/ContentfulFactories/NewsContentfulFactoryTest.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/NewsContentfulFactoryTest.cs
@@ -35,8 +35,8 @@ namespace StockportContentApiTests.Unit.ContentfulFactories
         public void ShouldNotAddDocumentsOrImageIfTheyAreLinks()
         {
             // Arrange
-            _contentfulNews.Documents.First().SystemProperties.Type = "Link";
-            _contentfulNews.Image.SystemProperties.Type = "Link";
+            _contentfulNews.Documents.First().SystemProperties.LinkType = "Link";
+            _contentfulNews.Image.SystemProperties.LinkType = "Link";
 
             // Mock
             _videoRepository.Setup(o => o.Process(_contentfulNews.Body)).Returns(_contentfulNews.Body);

--- a/test/StockportContentApiTests/Unit/ContentfulFactories/ProfileContentfulFactoryTest.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/ProfileContentfulFactoryTest.cs
@@ -31,9 +31,9 @@ namespace StockportContentApiTests.Unit.ContentfulFactories
         [Fact]
         public void ShouldNotAddBreadcrumbsOrAlertsOrImageIfTheyAreLinks()
         {
-            _contentfulProfile.Image.SystemProperties.Type = "Link";
-            _contentfulProfile.Breadcrumbs.First().Sys.Type = "Link";
-            _contentfulProfile.Alerts.First().Sys.Type = "Link";
+            _contentfulProfile.Image.SystemProperties.LinkType = "Link";
+            _contentfulProfile.Breadcrumbs.First().Sys.LinkType = "Link";
+            _contentfulProfile.Alerts.First().Sys.LinkType = "Link";
 
             var profile = _profileContentfulFactory.ToModel(_contentfulProfile);
 

--- a/test/StockportContentApiTests/Unit/ContentfulFactories/SectionContentfulFactoryTest.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/SectionContentfulFactoryTest.cs
@@ -102,8 +102,8 @@ namespace StockportContentApiTests.Unit.ContentfulFactories
         [Fact]
         public void ShouldNotAddDocumentsOrProfilesIfTheyAreLinks()
         {
-            _contentfulSection.Documents.First().SystemProperties.Type = "Link";
-            _contentfulSection.Profiles.First().Sys.Type = "Link";
+            _contentfulSection.Documents.First().SystemProperties.LinkType = "Link";
+            _contentfulSection.Profiles.First().Sys.LinkType = "Link";
             _videoRepository.Setup(o => o.Process(_contentfulSection.Body)).Returns(_contentfulSection.Body);
 
             var section = _sectionFactory.ToModel(_contentfulSection);

--- a/test/StockportContentApiTests/Unit/ContentfulFactories/TopicContentfulFactoryTest.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/TopicContentfulFactoryTest.cs
@@ -113,12 +113,12 @@ namespace StockportContentApiTests.Unit.ContentfulFactories
         [Fact]
         public void ShouldNotAddBreadcrumbsOrSubItemsOrSecondaryItemsOrTertiaryItemsOrImageOrAlertsIfTheyAreLinks()
         {
-            _contentfulTopic.Breadcrumbs.First().Sys.Type = "Link";
-            _contentfulTopic.SubItems.First().Sys.Type = "Link";
-            _contentfulTopic.SecondaryItems.First().Sys.Type = "Link";
-            _contentfulTopic.TertiaryItems.First().Sys.Type = "Link";
-            _contentfulTopic.Alerts.First().Sys.Type = "Link";
-            _contentfulTopic.BackgroundImage.SystemProperties.Type = "Link";
+            _contentfulTopic.Breadcrumbs.First().Sys.LinkType = "Link";
+            _contentfulTopic.SubItems.First().Sys.LinkType = "Link";
+            _contentfulTopic.SecondaryItems.First().Sys.LinkType = "Link";
+            _contentfulTopic.TertiaryItems.First().Sys.LinkType = "Link";
+            _contentfulTopic.Alerts.First().Sys.LinkType = "Link";
+            _contentfulTopic.BackgroundImage.SystemProperties.LinkType = "Link";
 
             var topic = _topicContentfulFactory.ToModel(_contentfulTopic);
 


### PR DESCRIPTION
There have been errors from old images, possibly not having a full system properties objects... so this is just adding in null checks. Some ( the 2nd commit ) are most likely unnecessary due to the model, but I wanted to treat it all with the same touch.

Also not changed a lot of the other "!=" null checks, due to a subsequent clean-up card being played after this.

Changed the Contentful Helper method "EntryIsNotALink" to use LinkType instead of string match of Link property.
![image](https://user-images.githubusercontent.com/24687851/213669122-2cbdf9e0-2275-4a3b-afe7-d89b32195ab6.png)

Updated Tests project to reflect the change mentioned above.

The fix is for when a dodgy image gets passed back, or mostly referenced by a content type, it just won't render the image, rather than break the whole page and throw an error.

GitHub displays the changes a bit strangely... if you're not sure, pull the branch and check it locally.