### PR TITLE
remove(AspNetCoreRateLimit): excess Nuget package

### DIFF
--- a/src/StockportContentApi/Program.cs
+++ b/src/StockportContentApi/Program.cs
@@ -33,7 +33,6 @@ try
             "Stockport Content API");
     });
     app.UseMiddleware<AuthenticationMiddleware>();
-    app.UseClientRateLimiting();
     app.UseStaticFiles();
     app.UseRouting();
     app.UseEndpoints(endpoints =>

--- a/src/StockportContentApi/Startup.cs
+++ b/src/StockportContentApi/Startup.cs
@@ -39,11 +39,6 @@ namespace StockportContentApi
             services.AddSingleton<ITimeProvider>(new TimeProvider());
             services.AddSingleton<IConfiguration>(Configuration);
             services.AddSingleton<IHttpContextAccessor, HttpContextAccessor>();
-            services.Configure<RateLimitConfiguration>(Configuration.GetSection("ClientRateLimiting"));
-            services.Configure<ClientRateLimitPolicies>(Configuration.GetSection("ClientRateLimitPolicies"));
-            services.AddSingleton<IRateLimitConfiguration, RateLimitConfiguration>();
-            services.AddSingleton<IClientPolicyStore, DistributedCacheClientPolicyStore>();
-            services.AddSingleton<IRateLimitCounterStore, DistributedCacheRateLimitCounterStore>();
 
             services.AddSingleton(_ => new ShortUrlRedirects(new Dictionary<string, RedirectDictionary>()));
             services.AddSingleton(_ => new LegacyUrlRedirects(new Dictionary<string, RedirectDictionary>()));

--- a/src/StockportContentApi/StockportContentApi.csproj
+++ b/src/StockportContentApi/StockportContentApi.csproj
@@ -11,7 +11,6 @@
   </PropertyGroup>
   <ItemGroup>
     <None Include="featureToggles.yml" CopyToPublishDirectory="PreserveNewest" />
-    <PackageReference Include="AspNetCoreRateLimit" Version="3.2.2" />
     <PackageReference Include="GeoCoordinate.NetCore" Version="1.0.0.1" />
     <PackageReference Include="jose-jwt" Version="4.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.11" />

--- a/src/StockportContentApi/app-config/appsettings.json
+++ b/src/StockportContentApi/app-config/appsettings.json
@@ -50,34 +50,6 @@
       "WithProcessId"
     ]
   },
-  "ClientRateLimiting": {
-    "EnableEndpointRateLimiting": true,
-    "StackBlockedRequests": false,
-    "HttpStatusCode": 429,
-    "EndpointWhitelist": [],
-    "GeneralRules": [
-      {
-        "Endpoint": "*",
-        "Period": "1s",
-        "Limit": 2
-      },
-      {
-        "Endpoint": "*",
-        "Period": "15m",
-        "Limit": 100
-      },
-      {
-        "Endpoint": "*",
-        "Period": "12h",
-        "Limit": 1000
-      },
-      {
-        "Endpoint": "*",
-        "Period": "7d",
-        "Limit": 10000
-      }
-    ]
-  },
   "Contentful": {
     "DeliveryUrl": "https://cdn.contentful.com",
     "UsePreviewAPI": false

--- a/src/StockportContentApi/globalusings.cs
+++ b/src/StockportContentApi/globalusings.cs
@@ -1,5 +1,4 @@
-﻿global using AspNetCoreRateLimit;
-global using Newtonsoft.Json;
+﻿global using Newtonsoft.Json;
 global using Serilog;
 global using StockportContentApi;
 global using StockportContentApi.Middleware;


### PR DESCRIPTION
Removed package that brought no value. Was designed for the API to accept a multitude of clients but in reality it only accepts one, and doesn't need to limit the request rate.