### PR TITLE
chore(SubItem): replace ComponentWidth field with Link

### DIFF
--- a/src/StockportContentApi/ContentfulFactories/SubItemContentfulFactory.cs
+++ b/src/StockportContentApi/ContentfulFactories/SubItemContentfulFactory.cs
@@ -26,36 +26,36 @@ public class SubItemContentfulFactory : IContentfulFactory<ContentfulReference, 
         List<SubItem> subItems = new();
         if (entry.SubItems is not null)
         {
-            foreach (var item in entry.SubItems.Where(EntryIsValid))
+            foreach (ContentfulReference item in entry.SubItems.Where(EntryIsValid))
             {
-                var newItem = new SubItem(item.Slug, GetEntryTitle(item), item.Teaser, item.Icon, GetEntryType(item), entry.ContentType, item.SunriseDate, item.SunsetDate, GetEntryImage(item), item.MailingListId, item.Body, new List<SubItem>(), item.ColourScheme, item.ComponentWidth);
+                SubItem newItem = new(item.Slug, GetEntryTitle(item), item.Teaser, item.Icon, GetEntryType(item), entry.ContentType, item.SunriseDate, item.SunsetDate, GetEntryImage(item), item.MailingListId, item.Body, new List<SubItem>(), item.Link, item.ColourScheme);
                 subItems.Add(newItem);
             }
         }
 
         if (entry.SecondaryItems != null)
         {
-            foreach (var item in entry.SecondaryItems.Where(EntryIsValid))
+            foreach (ContentfulReference item in entry.SecondaryItems.Where(EntryIsValid))
             {
-                var newItem = new SubItem(item.Slug, GetEntryTitle(item), item.Teaser, item.Icon, GetEntryType(item), entry.ContentType, item.SunriseDate, item.SunsetDate, GetEntryImage(item), item.MailingListId, item.Body, new List<SubItem>(), item.ColourScheme, item.ComponentWidth);
+                SubItem newItem = new(item.Slug, GetEntryTitle(item), item.Teaser, item.Icon, GetEntryType(item), entry.ContentType, item.SunriseDate, item.SunsetDate, GetEntryImage(item), item.MailingListId, item.Body, new List<SubItem>(), item.Link, item.ColourScheme);
                 subItems.Add(newItem);
             }
         }
 
         if (entry.TertiaryItems != null)
         {
-            foreach (var item in entry.TertiaryItems.Where(EntryIsValid))
+            foreach (ContentfulReference item in entry.TertiaryItems.Where(EntryIsValid))
             {
-                var newItem = new SubItem(item.Slug, GetEntryTitle(item), item.Teaser, item.Icon, GetEntryType(item), entry.ContentType, item.SunriseDate, item.SunsetDate, GetEntryImage(item), item.MailingListId, item.Body, new List<SubItem>(), item.ColourScheme, item.ComponentWidth);
+                SubItem newItem = new(item.Slug, GetEntryTitle(item), item.Teaser, item.Icon, GetEntryType(item), entry.ContentType, item.SunriseDate, item.SunsetDate, GetEntryImage(item), item.MailingListId, item.Body, new List<SubItem>(), item.Link, item.ColourScheme);
                 subItems.Add(newItem);
             }
         }
 
         if (entry.Sections != null)
         {
-            foreach (var section in entry.Sections.Where(EntryIsValid))
+            foreach (ContentfulSection section in entry.Sections.Where(EntryIsValid))
             {
-                var newSection = new SubItem($"{entry.Slug}/{section.Slug}", section.Title, section.Teaser, section.Icon, GetEntryType(section), entry.ContentType, section.SunriseDate, section.SunsetDate, GetEntryImage(section), entry.MailingListId, entry.Body, new List<SubItem>(), section.ColourScheme, section.ComponentWidth);
+                SubItem newSection = new SubItem($"{entry.Slug}/{section.Slug}", section.Title, section.Teaser, section.Icon, GetEntryType(section), entry.ContentType, section.SunriseDate, section.SunsetDate, GetEntryImage(section), entry.MailingListId, entry.Body, new List<SubItem>(), section.Link, section.ColourScheme);
                 subItems.Add(newSection);
             }
         }
@@ -67,7 +67,7 @@ public class SubItemContentfulFactory : IContentfulFactory<ContentfulReference, 
 
         var handledSlug = HandleSlugForGroupsHomepage(entry.Sys, entry.Slug);
 
-        return new SubItem(handledSlug, title, entry.Teaser, entry.Icon, type, entry.ContentType, entry.SunriseDate, entry.SunsetDate, image, entry.MailingListId, entry.Body, subItems, entry.ColourScheme, entry.ComponentWidth);
+        return new SubItem(handledSlug, title, entry.Teaser, entry.Icon, type, entry.ContentType, entry.SunriseDate, entry.SunsetDate, image, entry.MailingListId, entry.Body, subItems, entry.Link, entry.ColourScheme);
     }
 
     private static string HandleSlugForGroupsHomepage(SystemProperties sys, string entrySlug)

--- a/src/StockportContentApi/ContentfulModels/ContentfulReference.cs
+++ b/src/StockportContentApi/ContentfulModels/ContentfulReference.cs
@@ -27,5 +27,5 @@ public class ContentfulReference : IContentfulModel
     public string ContentType { get; set; } = string.Empty;
     public int MailingListId { get; set; }
     public string Body { get; set; }
-    public string ComponentWidth { get; set; } = "Content width";
+    public string Link { get; set; } = "Content width";
 }

--- a/src/StockportContentApi/Models/SubItem.cs
+++ b/src/StockportContentApi/Models/SubItem.cs
@@ -15,12 +15,12 @@ public class SubItem
     public string Image { get; set; }
     public int MailingListId { get; set; }
     public string Body { get; set; }
-    public string ComponentWidth { get; set; } = string.Empty;
+    public string Link { get; set; }
     public List<SubItem> SubItems { get; set; }
 
     public SubItem() { }
 
-    public SubItem(string slug, string title, string teaser, string icon, string type, string contentType, DateTime sunriseDate, DateTime sunsetDate, string image, int mailingListId, string body, List<SubItem> subItems, string colourScheme = "", string componentWidth = "")
+    public SubItem(string slug, string title, string teaser, string icon, string type, string contentType, DateTime sunriseDate, DateTime sunsetDate, string image, int mailingListId, string body, List<SubItem> subItems, string link, string colourScheme = "")
     {
         Slug = slug;
         Teaser = teaser;
@@ -35,6 +35,6 @@ public class SubItem
         Body = body;
         SubItems = subItems;
         ColourScheme = colourScheme;
-        ComponentWidth = componentWidth;
+        Link = link;
     }
 }

--- a/test/StockportContentApiTests/Unit/Builders/SubItemBuilder.cs
+++ b/test/StockportContentApiTests/Unit/Builders/SubItemBuilder.cs
@@ -13,7 +13,8 @@ public class SubItemBuilder
     private readonly string _image = "image";
     private readonly int _mailingListId = 111;
     private readonly string _body = "this is the body text of a sub item";
+    private readonly string _link = "external link";
     private readonly List<SubItem> _subItems = new();
 
-    public SubItem Build() => new(_slug, _title, _teaser, _icon, _type, _contentType, _sunriseDate, _sunsetDate, _image, _mailingListId, _body, _subItems);
+    public SubItem Build() => new(_slug, _title, _teaser, _icon, _type, _contentType, _sunriseDate, _sunsetDate, _image, _mailingListId, _body, _subItems, _link);
 }

--- a/test/StockportContentApiTests/Unit/ContentfulFactories/DirectoryContentfulFactoryTests.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/DirectoryContentfulFactoryTests.cs
@@ -52,7 +52,7 @@ public class DirectoryContentfulFactoryTests
             })
             .Build();
 
-        SubItem subItem = new("slug1", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 111, "body text", new List<SubItem>());
+        SubItem subItem = new("slug1", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 111, "body text", new List<SubItem>(), "external link");
         _subItemFactory.Setup(_ => _.ToModel(ContentfulReference.SubItems.First())).Returns(subItem);
 
         // Act

--- a/test/StockportContentApiTests/Unit/ContentfulFactories/FooterContentfulFactoryTest.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/FooterContentfulFactoryTest.cs
@@ -8,7 +8,7 @@ public class FooterContentfulFactoryTest
         // Arrange
         Mock<IContentfulFactory<ContentfulReference, SubItem>> factory = new();
         factory.Setup(_subItemFactory => _subItemFactory.ToModel(It.IsAny<ContentfulReference>()))
-            .Returns(new SubItem("slug", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 222, "body text", new List<SubItem>()));
+            .Returns(new SubItem("slug", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 222, "body text", new List<SubItem>(), "externalLink"));
        
         Mock<IContentfulFactory<ContentfulSocialMediaLink, SocialMediaLink>> socialMediaFactory = new();
         socialMediaFactory.Setup(_socialMediaFactory => _socialMediaFactory.ToModel(It.IsAny<ContentfulSocialMediaLink>())).Returns(new SocialMediaLink("sm-link-title", "sm-link-slug", "sm-link-icon", "https://link.url", "sm-link-accountName", "sm-link-screenReader"));

--- a/test/StockportContentApiTests/Unit/ContentfulFactories/ParentTopicContentfulFactoryTests.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/ParentTopicContentfulFactoryTests.cs
@@ -9,7 +9,7 @@ public class ParentTopicContentfulFactoryTests
     public ParentTopicContentfulFactoryTests()
     {
         _subitemContentfulFactory.Setup(subItem => subItem.ToModel(It.IsAny<ContentfulReference>()))
-                                .Returns(new SubItem("slug", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 123, "body text", new List<SubItem>()));
+                                .Returns(new SubItem("slug", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 123, "body text", new List<SubItem>(), "externalLink"));
         _timeProvider.Setup(timeProvider => timeProvider.Now())
                     .Returns(new DateTime(2017, 01, 02));
 
@@ -121,7 +121,7 @@ public class ParentTopicContentfulFactoryTests
             .Build();
 
         _subitemContentfulFactory.Setup(o => o.ToModel(It.Is<ContentfulReference>(x => x.Slug.Equals("article-slug"))))
-            .Returns(new SubItem("slug", "title", string.Empty, string.Empty, string.Empty, string.Empty, DateTime.MinValue, DateTime.MaxValue, string.Empty, 0, string.Empty, new List<SubItem>()));
+            .Returns(new SubItem("slug", "title", string.Empty, string.Empty, string.Empty, string.Empty, DateTime.MinValue, DateTime.MaxValue, string.Empty, 0, string.Empty, new List<SubItem>(), "externalLink"));
 
         // Act
         Topic result = _parentTopicContentfulFactory.ToModel(contentfulArticle);

--- a/test/StockportContentApiTests/Unit/ContentfulFactories/ShowcaseContentfulFactoryTest.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/ShowcaseContentfulFactoryTest.cs
@@ -6,7 +6,7 @@ public class ShowcaseContentfulFactoryTest
     public void ShouldCreateAShowcaseFromAContentfulShowcase()
     {
         List<SubItem> subItems = new() {
-            new("slug", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 123, "body text", new List<SubItem>()) };
+            new("slug", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 123, "body text", new List<SubItem>(), "externalLink") };
         Crumb crumb = new("title", "slug", "type");
 
         ContentfulShowcase contentfulShowcase = new ContentfulShowcaseBuilder()
@@ -20,7 +20,7 @@ public class ShowcaseContentfulFactoryTest
             .Build();
 
         Mock<IContentfulFactory<ContentfulReference, SubItem>> topicFactory = new();
-        topicFactory.Setup(o => o.ToModel(It.IsAny<ContentfulReference>())).Returns(new SubItem("slug", "title", "teaser", "icon", "type", "contenType", DateTime.MinValue, DateTime.MaxValue, "image", 123, "body text", new List<SubItem>()));
+        topicFactory.Setup(o => o.ToModel(It.IsAny<ContentfulReference>())).Returns(new SubItem("slug", "title", "teaser", "icon", "type", "contenType", DateTime.MinValue, DateTime.MaxValue, "image", 123, "body text", new List<SubItem>(), "externalLink"));
 
         Mock<IContentfulFactory<ContentfulAlert, Alert>> _alertFactory = new();
         _alertFactory.Setup(o => o.ToModel(It.IsAny<ContentfulAlert>())).Returns(new Alert("title", "", "", "", DateTime.MinValue, DateTime.MaxValue, string.Empty, false, string.Empty));
@@ -81,7 +81,7 @@ public class ShowcaseContentfulFactoryTest
 
         Mock<IContentfulFactory<ContentfulReference, SubItem>> topicFactory = new();
         topicFactory.Setup(o => o.ToModel(It.IsAny<ContentfulReference>()))
-            .Returns(new SubItem("slug", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 234, "body text", new List<SubItem>()));
+            .Returns(new SubItem("slug", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 234, "body text", new List<SubItem>(), "externalLink"));
 
         Mock<IContentfulFactory<ContentfulReference, Crumb>> crumbFactory = new();
 
@@ -149,7 +149,7 @@ public class ShowcaseContentfulFactoryTest
 
         Mock<IContentfulFactory<ContentfulReference, SubItem>> topicFactory = new();
         topicFactory.Setup(o => o.ToModel(It.IsAny<ContentfulReference>()))
-            .Returns(new SubItem("slug", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 456, "body text", new List<SubItem>()));
+            .Returns(new SubItem("slug", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 456, "body text", new List<SubItem>(), "externalLink"));
 
         Mock<IContentfulFactory<ContentfulReference, Crumb>> crumbFactory = new();
 
@@ -219,7 +219,7 @@ public class ShowcaseContentfulFactoryTest
 
         Mock<IContentfulFactory<ContentfulReference, SubItem>> topicFactory = new();
         topicFactory.Setup(o => o.ToModel(It.IsAny<ContentfulReference>()))
-            .Returns(new SubItem("slug", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 789, "body text", new List<SubItem>()));
+            .Returns(new SubItem("slug", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 789, "body text", new List<SubItem>(), "externalLink"));
 
         Mock<IContentfulFactory<ContentfulReference, Crumb>> crumbFactory = new Mock<IContentfulFactory<ContentfulReference, Crumb>>();
 

--- a/test/StockportContentApiTests/Unit/ContentfulFactories/TopicContentfulFactoryTest.cs
+++ b/test/StockportContentApiTests/Unit/ContentfulFactories/TopicContentfulFactoryTest.cs
@@ -42,13 +42,13 @@ public class TopicContentfulFactoryTest
         Crumb crumb = new("title", "slug", "type");
         _crumbFactory.Setup(_ => _.ToModel(_contentfulTopic.Breadcrumbs.First())).Returns(crumb);
 
-        SubItem subItem = new("slug1", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 111, "body text", new List<SubItem>());
+        SubItem subItem = new("slug1", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 111, "body text", new List<SubItem>(), "externalLink");
         _subItemFactory.Setup(_ => _.ToModel(_contentfulTopic.SubItems.First())).Returns(subItem);
 
-        SubItem secondaryItem = new("slug2", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 111, "body text", new List<SubItem>());
+        SubItem secondaryItem = new("slug2", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 111, "body text", new List<SubItem>(), "externalLink");
         _subItemFactory.Setup(_ => _.ToModel(_contentfulTopic.SecondaryItems.First())).Returns(secondaryItem);
 
-        SubItem tertiaryItem = new("slug3", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 111, "body text", new List<SubItem>());
+        SubItem tertiaryItem = new("slug3", "title", "teaser", "icon", "type", "contentType", DateTime.MinValue, DateTime.MaxValue, "image", 111, "body text", new List<SubItem>(), "externalLink");
 
         CallToActionBanner callToAction = new()
         {


### PR DESCRIPTION
ComponentWidth field is no longer needed as it will be defined in the ContentType. Link used for external links only