### PR TITLE
Events cache refactor

### DIFF
--- a/src/StockportContentApi/Config/CacheKeyConfig.cs
+++ b/src/StockportContentApi/Config/CacheKeyConfig.cs
@@ -1,0 +1,44 @@
+namespace StockportContentApi.Config;
+
+[ExcludeFromCodeCoverage]
+public class CacheKeyConfig
+{
+    public readonly string BusinessId;
+    private readonly Dictionary<string, string> _config = new();
+    public string EventsCacheKey;
+    public string NewsCacheKey;
+
+    public CacheKeyConfig(string eventsCacheKey, string newsCacheKey)
+    {
+        EventsCacheKey = eventsCacheKey;
+        NewsCacheKey = newsCacheKey;
+    }
+
+    public CacheKeyConfig(string businessId)
+    {
+        Utils.Ensure.ArgumentNotNullOrEmpty(businessId, "BUSINESS_ID");
+        BusinessId = businessId;
+    }
+
+    public CacheKeyConfig Add(string key, string value)
+    {
+        _config.Add(key, value);
+        return this;
+    }
+
+    public CacheKeyConfig Build()
+    {
+        EventsCacheKey = GetConfigValue($"{BusinessId.ToUpper()}_EventsCacheKey");
+        NewsCacheKey = GetConfigValue($"{BusinessId.ToUpper()}_NewsCacheKey");
+
+        return this;
+    }
+
+    private string GetConfigValue(string key)
+    {
+        if (_config.TryGetValue(key, out string value))
+            return value;
+
+        throw new ArgumentException($"No value found for '{key}' in the contentful config.");
+    }
+}

--- a/src/StockportContentApi/Controllers/EventController.cs
+++ b/src/StockportContentApi/Controllers/EventController.cs
@@ -3,6 +3,7 @@
 public class EventController : Controller
 {
     private readonly Func<string, ContentfulConfig> _createConfig;
+    private readonly Func<string, CacheKeyConfig> _cacheKeyConfig;
     private readonly Func<ContentfulConfig, EventCategoryRepository> _eventCategoryRepository;
     private readonly Func<ContentfulConfig, EventRepository> _eventRepository;
     private readonly ResponseHandler _handler;
@@ -12,6 +13,7 @@ public class EventController : Controller
 
     public EventController(ResponseHandler handler,
                         Func<string, ContentfulConfig> createConfig,
+                        Func<string, CacheKeyConfig> cacheKeyConfig,
                         Func<ContentfulConfig, EventRepository> eventRepository,
                         Func<ContentfulConfig, EventCategoryRepository> eventCategoryRepository,
                         Func<ContentfulConfig, ManagementRepository> managementRepository,
@@ -20,6 +22,7 @@ public class EventController : Controller
     {
         _handler = handler;
         _createConfig = createConfig;
+        _cacheKeyConfig = cacheKeyConfig;
         _eventRepository = eventRepository;
         _managementRepository = managementRepository;
         _eventCategoryRepository = eventCategoryRepository;
@@ -34,6 +37,7 @@ public class EventController : Controller
     public async Task<IActionResult> GetEventCategories(string businessId) =>
         await _handler.Get(() =>
         {
+            
             EventCategoryRepository eventRepository = _eventCategoryRepository(_createConfig(businessId));
 
             return eventRepository.GetEventCategories();
@@ -45,6 +49,7 @@ public class EventController : Controller
     [Route("v1/{businessId}/eventhomepage")]
     public async Task<IActionResult> Homepage(string businessId)
     {
+        CacheKeyConfig cacheKeyConfig = _cacheKeyConfig(businessId);
         EventCategoryRepository categoryRepository = _eventCategoryRepository(_createConfig(businessId));
         HttpResponse categoriesresponse = await categoryRepository.GetEventCategories();
         List<EventCategory> categories = categoriesresponse.Get<List<EventCategory>>();

--- a/src/StockportContentApi/Extensions/ServiceCollectionExtensions.cs
+++ b/src/StockportContentApi/Extensions/ServiceCollectionExtensions.cs
@@ -370,10 +370,11 @@ public static class ServiceCollectionExtensions
         services.AddSingleton<IVideoRepository>(p =>
            new VideoRepository(p.GetService<TwentyThreeConfig>(), p.GetService<IHttpClient>()));
 
-        services.AddSingleton<Func<ContentfulConfig, EventRepository>>(p =>
-            config =>
+        services.AddSingleton<Func<ContentfulConfig, CacheKeyConfig, EventRepository>>(p =>
+            (contentfulConfig, cacheKeyConfig) =>
                 new(
-                    config,
+                    contentfulConfig,
+                    cacheKeyConfig,
                     p.GetService<IContentfulClientManager>(),
                     p.GetService<ITimeProvider>(),
                     p.GetService<IContentfulFactory<ContentfulEvent, Event>>(),

--- a/src/StockportContentApi/Extensions/ServiceCollectionExtensions.cs
+++ b/src/StockportContentApi/Extensions/ServiceCollectionExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace StockportContentApi.Extensions;
+﻿using StockportContentApi.Config;
+
+namespace StockportContentApi.Extensions;
 
 [ExcludeFromCodeCoverage]
 public static class ServiceCollectionExtensions
@@ -293,6 +295,26 @@ public static class ServiceCollectionExtensions
     /// <param name="services"></param>
     /// <param name="configuration"></param>
     /// <returns></returns>
+    public static IServiceCollection AddCacheKeyConfig(this IServiceCollection services, IConfiguration configuration)
+    {
+        Func<string, CacheKeyConfig> cacheKeyConfig = businessId =>
+            new CacheKeyConfig(businessId)
+                .Add($"{businessId.ToUpper()}_EventsCacheKey", configuration[$"{businessId}:EventsCacheKey"])
+                .Add($"{businessId.ToUpper()}_NewsCacheKey", configuration[$"{businessId}:NewsCacheKey"])
+                .Build();
+       
+        services.AddTransient(_ => cacheKeyConfig);
+
+        return services;
+    }
+
+
+    /// <summary>
+    ///     Add custom contentful configuration
+    /// </summary>
+    /// <param name="services"></param>
+    /// <param name="configuration"></param>
+    /// <returns></returns>
     public static IServiceCollection AddContentfulConfig(this IServiceCollection services, IConfiguration configuration)
     {
         Func<string, ContentfulConfig> createConfig = businessId =>
@@ -402,13 +424,13 @@ public static class ServiceCollectionExtensions
                     p.GetService<IContentfulClientManager>(),
                     p.GetService<ILogger<EventRepository>>()));
 
-        services.AddSingleton<Func<ContentfulConfig, ShowcaseRepository>>(
-            p =>
-            {
-                return x => new(x, p.GetService<IContentfulFactory<ContentfulShowcase, Showcase>>(),
+        services.AddSingleton<Func<ContentfulConfig, CacheKeyConfig, ShowcaseRepository>>(p =>
+            (contentfulConfig, cacheKeyConfig) =>
+                new(contentfulConfig, p.GetService<IContentfulFactory<ContentfulShowcase, Showcase>>(),
                     p.GetService<IContentfulClientManager>(),
                     p.GetService<IContentfulFactory<ContentfulNews, News>>(),
-                    new(x,
+                    new(contentfulConfig,
+                        cacheKeyConfig,
                         p.GetService<IContentfulClientManager>(),
                         p.GetService<ITimeProvider>(),
                         p.GetService<IContentfulFactory<ContentfulEvent, Event>>(),
@@ -417,23 +439,24 @@ public static class ServiceCollectionExtensions
                         p.GetService<ILogger<EventRepository>>(),
                         p.GetService<IConfiguration>()),
                     p.GetService<ILogger<ShowcaseRepository>>()
-                );
-            });
+                )
+            );
 
-        services.AddSingleton<Func<ContentfulConfig, LandingPageRepository>>(
-            p =>
-            {
-                return x => new(x,
+        services.AddSingleton<Func<ContentfulConfig, CacheKeyConfig, LandingPageRepository>>(p =>
+            (contentfulConfig, cacheKeyConfig) =>
+                new(contentfulConfig,
                     p.GetService<IContentfulFactory<ContentfulLandingPage, LandingPage>>(),
                     p.GetService<IContentfulClientManager>(),
-                    new(x, p.GetService<IContentfulClientManager>(),
+                    new(contentfulConfig,
+                        cacheKeyConfig,
+                        p.GetService<IContentfulClientManager>(),
                         p.GetService<ITimeProvider>(),
                         p.GetService<IContentfulFactory<ContentfulEvent, Event>>(),
                         p.GetService<IContentfulFactory<ContentfulEventHomepage, EventHomepage>>(),
                         p.GetService<ICache>(),
                         p.GetService<ILogger<EventRepository>>(),
                         p.GetService<IConfiguration>()),
-                    new(x,
+                    new(contentfulConfig,
                         p.GetService<ITimeProvider>(),
                         p.GetService<IContentfulClientManager>(),
                         p.GetService<IContentfulFactory<ContentfulNews, News>>(),
@@ -441,8 +464,8 @@ public static class ServiceCollectionExtensions
                         p.GetService<ICache>(),
                         p.GetService<IConfiguration>()),
                     p.GetService<IContentfulFactory<ContentfulProfile, Profile>>()
-                );
-            });
+                )
+            );
 
         services.AddSingleton<Func<ContentfulConfig, IProfileRepository>>(
             p =>
@@ -524,24 +547,25 @@ public static class ServiceCollectionExtensions
             });
         services.AddSingleton<RedirectsRepository>();
         services.AddSingleton<IAuthenticationHelper>(p => new AuthenticationHelper());
-        services.AddSingleton<Func<ContentfulConfig, IGroupRepository>>(
-            p =>
-            {
-                return x => new GroupRepository(x, p.GetService<IContentfulClientManager>(),
-                    p.GetService<ITimeProvider>(),
-                    p.GetService<IContentfulFactory<ContentfulGroup, Group>>(),
-                    p.GetService<IContentfulFactory<ContentfulGroupCategory, GroupCategory>>(),
-                    p.GetService<IContentfulFactory<ContentfulGroupHomepage, GroupHomepage>>(),
-                    new(x, p.GetService<IContentfulClientManager>(),
+        services.AddSingleton<Func<ContentfulConfig, CacheKeyConfig, IGroupRepository>>(p =>
+                (contentfulConfig, cacheKeyConfig) =>
+                    new GroupRepository(contentfulConfig, p.GetService<IContentfulClientManager>(),
                         p.GetService<ITimeProvider>(),
-                        p.GetService<IContentfulFactory<ContentfulEvent, Event>>(),
-                        p.GetService<IContentfulFactory<ContentfulEventHomepage, EventHomepage>>(),
+                        p.GetService<IContentfulFactory<ContentfulGroup, Group>>(),
+                        p.GetService<IContentfulFactory<ContentfulGroupCategory, GroupCategory>>(),
+                        p.GetService<IContentfulFactory<ContentfulGroupHomepage, GroupHomepage>>(),
+                        new(contentfulConfig,
+                            cacheKeyConfig,
+                            p.GetService<IContentfulClientManager>(),
+                            p.GetService<ITimeProvider>(),
+                            p.GetService<IContentfulFactory<ContentfulEvent, Event>>(),
+                            p.GetService<IContentfulFactory<ContentfulEventHomepage, EventHomepage>>(),
+                            p.GetService<ICache>(),
+                            p.GetService<ILogger<EventRepository>>(),
+                            p.GetService<IConfiguration>()),
                         p.GetService<ICache>(),
-                        p.GetService<ILogger<EventRepository>>(),
-                        p.GetService<IConfiguration>()),
-                    p.GetService<ICache>(),
-                    p.GetService<IConfiguration>());
-            });
+                        p.GetService<IConfiguration>())
+        );
 
         services.AddSingleton<Func<ContentfulConfig, ContactUsIdRepository>>(
             p =>

--- a/src/StockportContentApi/Repositories/EventRepository.cs
+++ b/src/StockportContentApi/Repositories/EventRepository.cs
@@ -79,8 +79,11 @@ public class EventRepository : BaseRepository
         return homepage;
     }
 
-    public async Task<ContentfulCollection<ContentfulEventCategory>> GetContentfulEventCategories() =>
-        await _cache.GetFromCacheOrDirectlyAsync(_eventCategoriesCacheKey, GetContentfulEventCategoriesDirect, _eventsTimeout);
+    public async Task<ContentfulCollection<ContentfulEventCategory>> GetContentfulEventCategories() {
+        var categories = await _cache.GetFromCacheOrDirectlyAsync(_eventCategoriesCacheKey, GetContentfulEventCategoriesDirect, _eventsTimeout);
+        return categories;
+    }
+        
 
     /// <summary>
     /// Get event categories from contentful event categories type
@@ -171,7 +174,12 @@ public class EventRepository : BaseRepository
         if (limit > 0)
             events = events.Take(limit).ToList();
 
-        IEnumerable<string> eventCategories = (await GetContentfulEventCategories()).Select(x => x.Name);
+        var eventCategoriesCollection = await GetContentfulEventCategories();
+        IEnumerable<string> eventCategories = Enumerable.Empty<string>();
+
+        if(eventCategoriesCollection is not null)
+            eventCategories = eventCategoriesCollection.Select(eventCategory => eventCategory.Name);
+
         EventCalender eventCalender = new();
         eventCalender.SetEvents(events, eventCategories.ToList());
 

--- a/src/StockportContentApi/Repositories/EventRepository.cs
+++ b/src/StockportContentApi/Repositories/EventRepository.cs
@@ -9,11 +9,15 @@ public class EventRepository : BaseRepository
     private readonly DateComparer _dateComparer;
     private readonly int _eventsTimeout;
     private readonly IConfiguration _configuration;
+    private readonly CacheKeyConfig _cacheKeyConfig;
     private ILogger<EventRepository> _logger;
     private readonly ITimeProvider _timeProvider;
+    private readonly string _allEventsCacheKey;
+    private readonly string _eventCategoriesCacheKey;
 
     public EventRepository(
-        ContentfulConfig config,
+        ContentfulConfig contentfulConfig,
+        CacheKeyConfig cacheKeyConfig,
         IContentfulClientManager contentfulClientManager, ITimeProvider timeProvider,
         IContentfulFactory<ContentfulEvent, Event> contentfulFactory,
         IContentfulFactory<ContentfulEventHomepage, EventHomepage> contentfulEventHomepageFactory,
@@ -24,12 +28,15 @@ public class EventRepository : BaseRepository
         _contentfulFactory = contentfulFactory;
         _contentfulEventHomepageFactory = contentfulEventHomepageFactory;
         _dateComparer = new(timeProvider);
-        _client = contentfulClientManager.GetClient(config);
+        _client = contentfulClientManager.GetClient(contentfulConfig);
+        _cacheKeyConfig = cacheKeyConfig;
         _cache = cache;
         _logger = logger;
         _configuration = configuration;
         int.TryParse(_configuration["redisExpiryTimes:Events"], out _eventsTimeout);
         _timeProvider = timeProvider;
+        _allEventsCacheKey = $"{_cacheKeyConfig.EventsCacheKey}-all";
+        _eventCategoriesCacheKey = $"{_cacheKeyConfig.EventsCacheKey}-categories";
     }
 
     public async Task<HttpResponse> GetEventHomepage(int quantity = 3)
@@ -45,7 +52,7 @@ public class EventRepository : BaseRepository
 
     public async Task<IEnumerable<ContentfulEvent>> GetAllEventsForAGroup(string groupSlug)
     {
-        IList<ContentfulEvent> events = await _cache.GetFromCacheOrDirectlyAsync("event-all", GetAllEvents, _eventsTimeout);
+        IList<ContentfulEvent> events = await _cache.GetFromCacheOrDirectlyAsync(_allEventsCacheKey, GetAllEvents, _eventsTimeout);
         IEnumerable<ContentfulEvent> groupEvents = events.Where(singleEvent => singleEvent.Group.Slug.Equals(groupSlug));
         
         return groupEvents;
@@ -53,7 +60,7 @@ public class EventRepository : BaseRepository
 
     private async Task<EventHomepage> AddHomepageRowEvents(EventHomepage homepage, int quantity = 3)
     {
-        IList<ContentfulEvent> events = await _cache.GetFromCacheOrDirectlyAsync("event-all", GetAllEvents, _eventsTimeout);
+        IList<ContentfulEvent> events = await _cache.GetFromCacheOrDirectlyAsync(_allEventsCacheKey, GetAllEvents, _eventsTimeout);
         
         List<Event> liveEvents = GetAllEventsAndTheirRecurrences(events)
                                     .Where(singleEvent => _dateComparer.EventDateIsBetweenTodayAndLater(singleEvent.EventDate))
@@ -73,8 +80,12 @@ public class EventRepository : BaseRepository
     }
 
     public async Task<ContentfulCollection<ContentfulEventCategory>> GetContentfulEventCategories() =>
-        await _cache.GetFromCacheOrDirectlyAsync("contentful-event-categories", GetContentfulEventCategoriesDirect, _eventsTimeout);
+        await _cache.GetFromCacheOrDirectlyAsync(_eventCategoriesCacheKey, GetContentfulEventCategoriesDirect, _eventsTimeout);
 
+    /// <summary>
+    /// Get event categories from contentful event categories type
+    /// </summary>
+    /// <returns></returns>
     private async Task<ContentfulCollection<ContentfulEventCategory>> GetContentfulEventCategoriesDirect()
     {
         QueryBuilder<ContentfulEventCategory> eventCategoryBuilder = new QueryBuilder<ContentfulEventCategory>().ContentTypeIs("eventCategory").Include(1);
@@ -88,7 +99,7 @@ public class EventRepository : BaseRepository
     public async Task<HttpResponse> GetEvent(string slug, DateTime? date)
     {
         // does this need to retrieve all events and their occurences??
-        IList<ContentfulEvent> entries = await _cache.GetFromCacheOrDirectlyAsync("event-all", GetAllEvents, _eventsTimeout);
+        IList<ContentfulEvent> entries = await _cache.GetFromCacheOrDirectlyAsync(_allEventsCacheKey, GetAllEvents, _eventsTimeout);
         IEnumerable<Event> events = GetAllEventsAndTheirRecurrences(entries);
         Event eventItem = events.FirstOrDefault(singleEvent => singleEvent.Slug.Equals(slug));
 
@@ -116,7 +127,7 @@ public class EventRepository : BaseRepository
     public async Task<HttpResponse> Get(DateTime? dateFrom, DateTime? dateTo, string category, int limit,
         bool? displayFeatured, string tag, string price, double latitude, double longitude)
     {
-        IList<ContentfulEvent> entries = await _cache.GetFromCacheOrDirectlyAsync("event-all", GetAllEvents, _eventsTimeout);
+        IList<ContentfulEvent> entries = await _cache.GetFromCacheOrDirectlyAsync(_allEventsCacheKey, GetAllEvents, _eventsTimeout);
 
         if (entries is null || !entries.Any())
             return HttpResponse.Failure(HttpStatusCode.NotFound, "No events found");
@@ -160,16 +171,16 @@ public class EventRepository : BaseRepository
         if (limit > 0)
             events = events.Take(limit).ToList();
 
-        List<string> eventCategories = await GetCategories();
+        IEnumerable<string> eventCategories = (await GetContentfulEventCategories()).Select(x => x.Name);
         EventCalender eventCalender = new();
-        eventCalender.SetEvents(events, eventCategories);
+        eventCalender.SetEvents(events, eventCategories.ToList());
 
         return HttpResponse.Successful(eventCalender);
     }
 
     public async Task<HttpResponse> Get(string category)
     {
-        IList<ContentfulEvent> entries = await _cache.GetFromCacheOrDirectlyAsync("event-all", GetAllEvents, _eventsTimeout);
+        IList<ContentfulEvent> entries = await _cache.GetFromCacheOrDirectlyAsync(_allEventsCacheKey, GetAllEvents, _eventsTimeout);
 
         if (entries is null || !entries.Any())
             return HttpResponse.Failure(HttpStatusCode.NotFound, "No events found");
@@ -190,7 +201,7 @@ public class EventRepository : BaseRepository
 
     public virtual async Task<List<Event>> GetEventsByCategory(string category, bool onlyNextOccurrence)
     {
-        IList<ContentfulEvent> entries = await _cache.GetFromCacheOrDirectlyAsync("event-all", GetAllEvents, _eventsTimeout);
+        IList<ContentfulEvent> entries = await _cache.GetFromCacheOrDirectlyAsync(_allEventsCacheKey, GetAllEvents, _eventsTimeout);
 
         List<Event> events = GetAllEventsAndTheirRecurrences(entries).Where(e => string.IsNullOrWhiteSpace(category)
                                     || e.EventCategories.Select(c => c.Slug.ToLower()).Contains(category.ToLower())
@@ -208,7 +219,7 @@ public class EventRepository : BaseRepository
 
     public virtual async Task<List<Event>> GetEventsByTag(string tag, bool onlyNextOccurrence)
     {
-        IList<ContentfulEvent> entries = await _cache.GetFromCacheOrDirectlyAsync("event-all", GetAllEvents, _eventsTimeout);
+        IList<ContentfulEvent> entries = await _cache.GetFromCacheOrDirectlyAsync(_allEventsCacheKey, GetAllEvents, _eventsTimeout);
 
         List<Event> events = GetAllEventsAndTheirRecurrences(entries).Where(e => string.IsNullOrWhiteSpace(tag)
                                     || e.Tags.Contains(tag.ToLower()))
@@ -268,7 +279,7 @@ public class EventRepository : BaseRepository
 
     public async Task<List<Event>> GetLinkedEvents<T>(string slug)
     {
-        IList<ContentfulEvent> entries = await _cache.GetFromCacheOrDirectlyAsync("event-all", GetAllEvents, _eventsTimeout);
+        IList<ContentfulEvent> entries = await _cache.GetFromCacheOrDirectlyAsync(_allEventsCacheKey, GetAllEvents, _eventsTimeout);
 
         List<Event> events = GetAllEventsAndTheirRecurrences(entries).Where(e => e.Group.Slug.Equals(slug))
                                 .Where(e => _dateComparer.EventDateIsBetweenTodayAndLater(e.EventDate))
@@ -280,20 +291,20 @@ public class EventRepository : BaseRepository
         return GetNextOccurenceOfEvents(events);
     }
 
-    [Obsolete]
-    public async Task<List<string>> GetCategories() =>
-        await _cache.GetFromCacheOrDirectlyAsync("event-categories", GetCategoriesDirect, _eventsTimeout);
+    //[Obsolete]
+    //public async Task<List<string>> GetCategories() =>
+    //    await _cache.GetFromCacheOrDirectlyAsync("event-categories", GetCategoriesDirect, _eventsTimeout);
 
-    [Obsolete]
-    private async Task<List<string>> GetCategoriesDirect()
-    {
-        ContentType eventType = await _client.GetContentType("events");
-        InValuesValidator validation = eventType.Fields.First(f => f.Name.Equals("Categories")).Items.Validations[0] as InValuesValidator;
+    //[Obsolete]
+    //private async Task<List<string>> GetCategoriesDirect()
+    //{
+    //    ContentType eventType = await _client.GetContentType("events");
+    //    InValuesValidator validation = eventType.Fields.First(f => f.Name.Equals("Categories")).Items.Validations[0] as InValuesValidator;
 
-        return !validation.RequiredValues.Any()
-            ? null
-            : validation.RequiredValues;
-    }
+    //    return !validation.RequiredValues.Any()
+    //        ? null
+    //        : validation.RequiredValues;
+    //}
 
     public async Task<ContentfulEvent> GetContentfulEvent(string slug)
     {

--- a/src/StockportContentApi/Startup.cs
+++ b/src/StockportContentApi/Startup.cs
@@ -69,6 +69,7 @@ public class Startup
         services.AddHelpers();
         services.AddRedirects(Configuration);
         services.AddContentfulConfig(Configuration);
+        services.AddCacheKeyConfig(Configuration);
         services.AddOptions();
 
         _logger.Information("CONTENTAPI: STARTUP : ConfigureServices : Adding Contentful Clients");

--- a/src/StockportContentApi/app-config/appsettings.json
+++ b/src/StockportContentApi/app-config/appsettings.json
@@ -6,6 +6,13 @@
       "iag-contentapi"
     ]
   },
+  "stockportgov:EventsCacheKey": "smbc-events",
+  "stockportgov:NewsCacheKey": "smbc-news",
+  "healthystockport:EventsCacheKey": "smbc-events",
+  "healthystockport:NewsCacheKey": "smbc-news",
+  "stockroom:EventsCacheKey": "stockroom-events",
+  "stockroom:NewsCacheKey": "stockroom-news",
+  
   "secrets-location": "c:\\secrets\\contentapi",  
   "UseAWSSecretManager": false,
   "UseRedisSessions": "false",

--- a/src/StockportContentApi/app-config/appsettings.json
+++ b/src/StockportContentApi/app-config/appsettings.json
@@ -6,14 +6,14 @@
       "iag-contentapi"
     ]
   },
-  "stockportgov:EventsCacheKey": "smbc-events",
-  "stockportgov:NewsCacheKey": "smbc-news",
-  "healthystockport:EventsCacheKey": "smbc-events",
-  "healthystockport:NewsCacheKey": "smbc-news",
-  "stockroom:EventsCacheKey": "stockroom-events",
-  "stockroom:NewsCacheKey": "stockroom-news",
-  
-  "secrets-location": "c:\\secrets\\contentapi",  
+  "STOCKPORTGOV:EventsCacheKey": "smbc-events",
+  "STOCKPORTGOV:NewsCacheKey": "smbc-news",
+  "HEALTHYSTOCKPORT:EventsCacheKey": "smbc-events",
+  "HEALTHYSTOCKPORT:NewsCacheKey": "smbc-news",
+  "STOCKROOM:EventsCacheKey": "stockroom-events",
+  "STOCKROOM:NewsCacheKey": "stockroom-news",
+
+  "secrets-location": "c:\\secrets\\contentapi",
   "UseAWSSecretManager": false,
   "UseRedisSessions": "false",
   "UseLocalCache": "true",

--- a/test/StockportContentApiTests/Unit/Repositories/EventRepositoryTests.cs
+++ b/test/StockportContentApiTests/Unit/Repositories/EventRepositoryTests.cs
@@ -5,6 +5,7 @@ public class EventRepositoryTests
     private readonly Mock<IContentfulFactory<ContentfulAlert, Alert>> _alertFactory = new();
     private readonly Mock<ICache> _cacheWrapper = new();
     private readonly ContentfulConfig _config;
+    private readonly CacheKeyConfig _cacheKeyconfig;
     private readonly Mock<IConfiguration> _configuration = new();
     private readonly Mock<IContentfulClient> _contentfulClient = new();
     private readonly Mock<IContentfulClientManager> _contentfulClientManager = new();
@@ -30,6 +31,11 @@ public class EventRepositoryTests
             .Add("TEST_ENVIRONMENT", "master")
             .Build();
 
+        _cacheKeyconfig = new CacheKeyConfig("test")
+            .Add("TEST_EventsCacheKey", "testEvetsCacheKey")
+            .Add("TEST_NewsCacheKey", "testNewsCacheKey")
+            .Build();
+
         // Mock
         _mockTimeProvider.Setup(o => o.Now()).Returns(new DateTime(2017, 01, 01));
 
@@ -49,7 +55,7 @@ public class EventRepositoryTests
         _configuration.Setup(_ => _["redisExpiryTimes:Articles"]).Returns("60");
         _configuration.Setup(_ => _["redisExpiryTimes:Events"]).Returns("60");
 
-        _repository = new(_config, _contentfulClientManager.Object,
+        _repository = new(_config, _cacheKeyconfig, _contentfulClientManager.Object,
             _mockTimeProvider.Object, contentfulFactory, eventHomepageFactory, _cacheWrapper.Object, _logger.Object,
             _configuration.Object);
     }
@@ -742,7 +748,7 @@ public class EventRepositoryTests
         _eventFactory.Setup(g => g.ToModel(It.IsAny<ContentfulEvent>())).Returns(theEvent);
 
         // Act
-        EventRepository repository = new(_config, _contentfulClientManager.Object, _mockTimeProvider.Object,
+        EventRepository repository = new(_config, _cacheKeyconfig, _contentfulClientManager.Object, _mockTimeProvider.Object,
             _eventFactory.Object, _eventHomepageFactory.Object, _cacheWrapper.Object, _logger.Object,
             _configuration.Object);
         HttpResponse result = await repository.Get("category");
@@ -770,7 +776,7 @@ public class EventRepositoryTests
         _eventFactory.Setup(g => g.ToModel(It.IsAny<ContentfulEvent>())).Returns(theEvent);
 
         // Act
-        EventRepository repository = new(_config, _contentfulClientManager.Object, _mockTimeProvider.Object,
+        EventRepository repository = new(_config, _cacheKeyconfig, _contentfulClientManager.Object, _mockTimeProvider.Object,
             _eventFactory.Object, _eventHomepageFactory.Object, _cacheWrapper.Object, _logger.Object,
             _configuration.Object);
         HttpResponse result = await repository.Get("category-tag");

--- a/test/StockportContentApiTests/Unit/Repositories/EventRepositoryTests.cs
+++ b/test/StockportContentApiTests/Unit/Repositories/EventRepositoryTests.cs
@@ -32,7 +32,7 @@ public class EventRepositoryTests
             .Build();
 
         _cacheKeyconfig = new CacheKeyConfig("test")
-            .Add("TEST_EventsCacheKey", "testEvetsCacheKey")
+            .Add("TEST_EventsCacheKey", "testEventsCacheKey")
             .Add("TEST_NewsCacheKey", "testNewsCacheKey")
             .Build();
 
@@ -72,7 +72,7 @@ public class EventRepositoryTests
         _eventCategoryFactory.Setup(o => o.ToModel(It.IsAny<ContentfulEventCategory>()))
             .Returns(new EventCategory("category", "category", "icon"));
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         // Act - return events using a method which checks occurances
@@ -93,7 +93,7 @@ public class EventRepositoryTests
 
         List<ContentfulEvent> events = new() { rawEvent };
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         // Act
@@ -129,7 +129,7 @@ public class EventRepositoryTests
             Items = new List<ContentfulEvent> { anEvent }
         };
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         QueryBuilder<ContentfulEvent> builder = new QueryBuilder<ContentfulEvent>().ContentTypeIs("events")
@@ -151,7 +151,7 @@ public class EventRepositoryTests
         _mockTimeProvider.Setup(o => o.Now()).Returns(new DateTime(2015, 08, 5));
 
         _cacheWrapper
-            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
                 It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60))))
             .ReturnsAsync(new List<ContentfulEvent>());
 
@@ -169,7 +169,7 @@ public class EventRepositoryTests
         ContentfulEvent anEvent = new ContentfulEventBuilder().EventDate(new(2016, 09, 08)).Build();
         ContentfulEvent anotherEvent = new ContentfulEventBuilder().EventDate(new(2016, 10, 08)).Build();
         List<ContentfulEvent> events = new() { anEvent, anotherEvent };
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         // Act
@@ -246,7 +246,7 @@ public class EventRepositoryTests
                 .Occurrences(occurences)
                 .Build();
         List<ContentfulEvent> events = new() { anEvent };
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         HttpResponse response = AsyncTestHelper.Resolve(_repository.Get(null, null, null, 0, null, null, null, 0, 0));
@@ -272,7 +272,7 @@ public class EventRepositoryTests
 
         List<ContentfulEvent> events = new() { anEvent };
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         HttpResponse response = AsyncTestHelper.Resolve(_repository.Get(null, null, null, 0, null, null, null, 0, 0));
@@ -299,7 +299,7 @@ public class EventRepositoryTests
                 .Build();
         List<ContentfulEvent> events = new() { anEvent };
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         HttpResponse response =
@@ -327,7 +327,7 @@ public class EventRepositoryTests
                 .Build();
         List<ContentfulEvent> events = new() { anEvent };
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         HttpResponse response = AsyncTestHelper.Resolve(_repository.Get(null, null, null, 0, null, null, null, 0, 0));
@@ -353,7 +353,7 @@ public class EventRepositoryTests
                 .Build();
         List<ContentfulEvent> events = new() { anEvent };
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         HttpResponse response = AsyncTestHelper.Resolve(_repository.Get(null, null, null, 0, null, null, null, 0, 0));
@@ -380,7 +380,7 @@ public class EventRepositoryTests
                 .Build();
         List<ContentfulEvent> events = new() { anEvent };
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         HttpResponse response = AsyncTestHelper.Resolve(_repository.Get(null, null, null, 0, null, null, null, 0, 0));
@@ -404,7 +404,7 @@ public class EventRepositoryTests
         ContentfulEvent anotherEvent = new ContentfulEventBuilder().EventDate(new(2017, 04, 01)).Build();
 
         List<ContentfulEvent> events = new() { anEvent, anotherEvent };
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         // Act
@@ -434,7 +434,7 @@ public class EventRepositoryTests
         _eventCategoryFactory.Setup(o => o.ToModel(contentfulCategory1)).Returns(category1);
         _eventCategoryFactory.Setup(o => o.ToModel(contentfulCategory2)).Returns(category2);
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         // Act
@@ -461,7 +461,7 @@ public class EventRepositoryTests
             new ContentfulEventBuilder().EventCategoryList(new() { contentfulCategory2 }).Build();
         List<ContentfulEvent> events = new() { anEvent, anotherEvent };
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         _eventCategoryFactory.Setup(o => o.ToModel(contentfulCategory1)).Returns(category1);
@@ -511,7 +511,7 @@ public class EventRepositoryTests
         _eventCategoryFactory.Setup(o => o.ToModel(contentfulCategory3))
             .Returns(new EventCategory("Category 3", "category-3", "icon3"));
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         // Act
@@ -533,7 +533,7 @@ public class EventRepositoryTests
         List<ContentfulEvent> events = new() { anEvent, anotherEvent, aThirdEvent };
 
         _mockTimeProvider.Setup(o => o.Now()).Returns(new DateTime(2017, 08, 08));
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         HttpResponse response = AsyncTestHelper.Resolve(_repository.Get(null, null, null, 2, true, null, null, 0, 0));
@@ -556,7 +556,7 @@ public class EventRepositoryTests
 
         _mockTimeProvider.Setup(o => o.Now()).Returns(new DateTime(2017, 08, 08));
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         HttpResponse response = AsyncTestHelper.Resolve(_repository.Get(null, null, null, 2, true, null, null, 0, 0));
@@ -576,10 +576,23 @@ public class EventRepositoryTests
             new ContentfulEventBuilder().Featured(false).EventDate(new(2017, 10, 10)).Build();
         ContentfulEvent aThirdEvent = new ContentfulEventBuilder().Featured(false).EventDate(new(2017, 09, 15)).Build();
         List<ContentfulEvent> events = new() { anEvent, anotherEvent, aThirdEvent };
+        ContentfulCollection<ContentfulEventCategory> categoryCollection = new (){
+            Items = new List<ContentfulEventCategory>() { new ContentfulEventCategory() { Name = "test", Slug="test"}}
+        };
 
         _mockTimeProvider.Setup(o => o.Now()).Returns(new DateTime(2017, 08, 08));
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
-            It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
+
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(
+            It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
+            It.IsAny<Func<Task<IList<ContentfulEvent>>>>(),
+            It.Is<int>(s => s.Equals(60))))
+            .ReturnsAsync(events);
+
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(
+            It.Is<string>(s => s.Equals("testEventsCacheKey-categories")),
+            It.IsAny<Func<Task<ContentfulCollection<ContentfulEventCategory>>>>(), 
+            It.Is<int>(s => s.Equals(60))))
+            .ReturnsAsync(categoryCollection);
 
         HttpResponse response = AsyncTestHelper.Resolve(_repository.Get(null, null, null, 2, true, null, null, 0, 0));
 
@@ -602,7 +615,7 @@ public class EventRepositoryTests
             .EventDate(new(2017, 09, 15)).Build();
         List<ContentfulEvent> events = new() { anEvent, anotherEvent, aThirdEvent };
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         Group group = new GroupBuilder().Slug("zumba-fitness").Build();
@@ -632,7 +645,7 @@ public class EventRepositoryTests
         aThirdEvent.Group.Slug = "kersal-rugby";
         List<ContentfulEvent> events = new() { anEvent, anotherEvent, aThirdEvent };
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         Group group = new GroupBuilder().Slug("zumba-fitness").Build();
@@ -664,7 +677,7 @@ public class EventRepositoryTests
         aThirdEvent.Group.Slug = "kersal-rugby";
         List<ContentfulEvent> events = new() { anEvent, anotherEvent, aThirdEvent };
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         Group group = new GroupBuilder().Slug("zumba-fitness").Build();
@@ -697,7 +710,7 @@ public class EventRepositoryTests
         aThirdEvent.Group.Slug = "zumba-fitness";
         List<ContentfulEvent> events = new() { anEvent, anotherEvent, aThirdEvent };
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         Group group = new GroupBuilder().Slug("zumba-fitness").Build();
@@ -720,7 +733,7 @@ public class EventRepositoryTests
     {
         //Arrange
         _cacheWrapper
-            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
                 It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60))))
             .ReturnsAsync((List<ContentfulEvent>)null);
 
@@ -743,7 +756,7 @@ public class EventRepositoryTests
         Event theEvent = new EventBuilder().EventCategories(new() { new("category", "category", "category") }).Build();
 
         // Mock
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
         _eventFactory.Setup(g => g.ToModel(It.IsAny<ContentfulEvent>())).Returns(theEvent);
 
@@ -771,7 +784,7 @@ public class EventRepositoryTests
         Event theEvent = new EventBuilder().Tags(new() { "category-tag" }).Build();
 
         // Mock
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
         _eventFactory.Setup(g => g.ToModel(It.IsAny<ContentfulEvent>())).Returns(theEvent);
 
@@ -799,7 +812,7 @@ public class EventRepositoryTests
         List<ContentfulEvent> events = new() { firstEvent, secondEvent, thirdEvent };
 
         _mockTimeProvider.Setup(o => o.Now()).Returns(new DateTime(2017, 08, 08));
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         // Act

--- a/test/StockportContentApiTests/Unit/Repositories/GroupRepositoryTests.cs
+++ b/test/StockportContentApiTests/Unit/Repositories/GroupRepositoryTests.cs
@@ -1,4 +1,5 @@
-﻿using StockportContentApi.Constants;
+﻿using StockportContentApi.Config;
+using StockportContentApi.Constants;
 
 namespace StockportContentApiTests.Unit.Repositories;
 
@@ -7,6 +8,7 @@ public class GroupRepositoryTests
     private readonly Mock<ICache> _cacheWrapper;
     private readonly Mock<IContentfulClient> _client;
     private readonly Mock<IConfiguration> _configuration;
+    private readonly CacheKeyConfig _cacheKeyconfig;
     private readonly Mock<IContentfulFactory<ContentfulEvent, Event>> _eventFactory;
     private readonly Mock<IContentfulFactory<ContentfulEventHomepage, EventHomepage>> _eventHomepageFactory;
     private readonly EventRepository _eventRepository;
@@ -25,6 +27,12 @@ public class GroupRepositoryTests
             .Add("TEST_ACCESS_KEY", "KEY")
             .Add("TEST_MANAGEMENT_KEY", "KEY")
             .Add("TEST_ENVIRONMENT", "master")
+        .Build();
+
+
+        _cacheKeyconfig = new CacheKeyConfig("test")
+            .Add("TEST_EventsCacheKey", "testEventsCacheKey")
+            .Add("TEST_NewsCacheKey", "testNewsCacheKey")
             .Build();
 
         _groupFactory = new();
@@ -44,7 +52,7 @@ public class GroupRepositoryTests
         _client = new();
         contentfulClientManager.Setup(o => o.GetClient(config)).Returns(_client.Object);
 
-        _eventRepository = new(config, contentfulClientManager.Object, _timeProvider.Object, _eventFactory.Object,
+        _eventRepository = new(config, _cacheKeyconfig, contentfulClientManager.Object, _timeProvider.Object, _eventFactory.Object,
             _eventHomepageFactory.Object, _cacheWrapper.Object, _logger.Object, _configuration.Object);
         _repository = new(config, contentfulClientManager.Object, _timeProvider.Object, _groupFactory.Object,
             _groupCategoryFactory.Object, _groupHomepageContentfulFactory.Object, _eventRepository,
@@ -69,7 +77,7 @@ public class GroupRepositoryTests
             It.IsAny<CancellationToken>())).ReturnsAsync(collection);
 
         _cacheWrapper
-            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
                 It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60))))
             .ReturnsAsync(new List<ContentfulEvent>());
 
@@ -104,7 +112,7 @@ public class GroupRepositoryTests
             It.IsAny<CancellationToken>())).ReturnsAsync(collection);
 
         _cacheWrapper
-            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
                 It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60))))
             .ReturnsAsync(new List<ContentfulEvent>());
 
@@ -141,7 +149,7 @@ public class GroupRepositoryTests
             It.IsAny<CancellationToken>())).ReturnsAsync(collection);
 
         _cacheWrapper
-            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
                 It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60))))
             .ReturnsAsync(new List<ContentfulEvent>());
 
@@ -178,7 +186,7 @@ public class GroupRepositoryTests
             It.IsAny<CancellationToken>())).ReturnsAsync(collection);
 
         _cacheWrapper
-            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
                 It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60))))
             .ReturnsAsync(new List<ContentfulEvent>());
 
@@ -214,7 +222,7 @@ public class GroupRepositoryTests
             It.IsAny<CancellationToken>())).ReturnsAsync(collection);
 
         _cacheWrapper
-            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
                 It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60))))
             .ReturnsAsync(new List<ContentfulEvent>());
 
@@ -250,7 +258,7 @@ public class GroupRepositoryTests
             It.IsAny<CancellationToken>())).ReturnsAsync(collection);
 
         _cacheWrapper
-            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
                 It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60))))
             .ReturnsAsync(new List<ContentfulEvent>());
 
@@ -451,7 +459,7 @@ public class GroupRepositoryTests
 
         _groupFactory.Setup(o => o.ToModel(contentfulGroupWithlocation)).Returns(groupWithLocation);
         _cacheWrapper
-            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
                 It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60))))
             .ReturnsAsync(new List<ContentfulEvent>());
 
@@ -486,7 +494,7 @@ public class GroupRepositoryTests
             It.IsAny<CancellationToken>())).ReturnsAsync(collection);
 
         _cacheWrapper
-            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+            .Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
                 It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60))))
             .ReturnsAsync(new List<ContentfulEvent>());
         _groupFactory.Setup(o => o.ToModel(contentfulGroupWithlocation)).Returns(groupWithLocation);

--- a/test/StockportContentApiTests/Unit/Repositories/LandingPageRepositoryTests.cs
+++ b/test/StockportContentApiTests/Unit/Repositories/LandingPageRepositoryTests.cs
@@ -37,6 +37,13 @@ public class LandingPageRepositoryTests
     public LandingPageRepositoryTests()
     {
         ContentfulConfig config = BuildContentfulConfig();
+
+        
+        CacheKeyConfig cacheKeyconfig = new CacheKeyConfig("test")
+            .Add("TEST_EventsCacheKey", "testEventsCacheKey")
+            .Add("TEST_NewsCacheKey", "testNewsCacheKey")
+            .Build();
+
         _timeprovider.Setup(time => time.Now()).Returns(DateTime.Today.AddDays(1));
         
         Mock<IContentfulClientManager> contentfulClientManager = SetupContentfulClientManager(config);
@@ -52,6 +59,7 @@ public class LandingPageRepositoryTests
                             _configuration.Object);
         
         _eventRepository = new(config,
+                            cacheKeyconfig,
                             contentfulClientManager.Object,
                             _timeprovider.Object,
                             _eventFactory.Object,

--- a/test/StockportContentApiTests/Unit/Repositories/ShowcaseRepositoryTests.cs
+++ b/test/StockportContentApiTests/Unit/Repositories/ShowcaseRepositoryTests.cs
@@ -11,7 +11,6 @@ public class ShowcaseRepositoryTests
     private readonly Mock<IContentfulFactory<ContentfulEventHomepage, EventHomepage>> _eventHomepageFactory;
     private readonly Mock<ILogger<ShowcaseRepository>> _mockLogger;
     private readonly ShowcaseRepository _repository;
-
     private readonly Mock<ITimeProvider> _timeprovider;
     private readonly Mock<IContentfulFactory<ContentfulReference, SubItem>> _topicFactory;
 
@@ -23,6 +22,11 @@ public class ShowcaseRepositoryTests
             .Add("TEST_ACCESS_KEY", "KEY")
             .Add("TEST_MANAGEMENT_KEY", "KEY")
             .Add("TEST_ENVIRONMENT", "master")
+            .Build();
+
+        CacheKeyConfig cacheKeyconfig = new CacheKeyConfig("test")
+            .Add("TEST_EventsCacheKey", "testEventsCacheKey")
+            .Add("TEST_NewsCacheKey", "testNewsCacheKey")
             .Build();
 
         _topicFactory = new();
@@ -77,7 +81,7 @@ public class ShowcaseRepositoryTests
         _configuration = new();
         _configuration.Setup(_ => _["redisExpiryTimes:Events"]).Returns("60");
 
-        EventRepository eventRepository = new(config, contentfulClientManager.Object, _timeprovider.Object,
+        EventRepository eventRepository = new(config, cacheKeyconfig, contentfulClientManager.Object, _timeprovider.Object,
             _eventFactory.Object, _eventHomepageFactory.Object, _cacheWrapper.Object, _logger.Object,
             _configuration.Object);
 
@@ -144,7 +148,7 @@ public class ShowcaseRepositoryTests
                     It.IsAny<CancellationToken>()))
             .ReturnsAsync(collection);
 
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
 
         // Act
@@ -180,7 +184,7 @@ public class ShowcaseRepositoryTests
 
         ContentfulEvent rawEvent = new ContentfulEventBuilder().Slug(slug).EventDate(new(2017, 4, 1)).Build();
         List<ContentfulEvent> events = new() { rawEvent };
-        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("event-all")),
+        _cacheWrapper.Setup(o => o.GetFromCacheOrDirectlyAsync(It.Is<string>(s => s.Equals("testEventsCacheKey-all")),
             It.IsAny<Func<Task<IList<ContentfulEvent>>>>(), It.Is<int>(s => s.Equals(60)))).ReturnsAsync(events);
         Event modelledEvent = new("title",
                                 "event-slug",


### PR DESCRIPTION
Updates events repo to enable - retrieval of a custom amount of events on building homepage and to enable multiple events cache and for them to be shared between sites depending on config options.